### PR TITLE
Feature/update release checks

### DIFF
--- a/.github/actions/check-version-release/action.yml
+++ b/.github/actions/check-version-release/action.yml
@@ -27,7 +27,7 @@ runs:
       PYPROJECT_EQUALS_GITHUB_RELEASE=$(python -c "from packaging.version import Version; print(Version('${PYPROJECT_VERSION}') == Version('${GITHUB_RELEASE_VERSION}'))")
       echo "PYPROJECT_EQUALS_GITHUB_RELEASE=${PYPROJECT_EQUALS_GITHUB_RELEASE}"
 
-      if $PYPROJECT_EQUALS_GITHUB_RELEASE; then
+      if [[ PYPROJECT_EQUALS_GITHUB_RELEASE ]]; then
         echo "The pyproject.toml version is equal to the latest GitHub release."
       else
         echo "The pyproject.toml version is not equal to the the latest GitHub release."

--- a/.github/actions/check-version-release/action.yml
+++ b/.github/actions/check-version-release/action.yml
@@ -1,0 +1,34 @@
+name: check-pyproject-version
+description: Check that the pyproject.toml version is greater than the latest GitHub release
+
+runs:
+  using: composite
+  steps:
+  - name: Checkout Repository
+    uses: actions/checkout@v4
+
+  - name: Setup Python
+    uses: actions/setup-python@v4
+    with:
+      python-version: "3.10"    
+
+  - shell: bash
+    run: |
+      pip install packaging==24.0
+      PYPROJECT_VERSION=$(python -c "from src import cpr_sdk; print(cpr_sdk.__version__)")
+      echo "PYPROJECT_VERSION=${PYPROJECT_VERSION}"
+
+      GITHUB_RELEASE_VERSION=$(curl --silent "https://api.github.com/repos/climatepolicyradar/cpr-sdk/releases/latest" | jq -r '.tag_name')
+      # remove the "v" from the version
+      GITHUB_RELEASE_VERSION=${GITHUB_RELEASE_VERSION#v}
+      echo "GITHUB_RELEASE_VERSION=${GITHUB_RELEASE_VERSION}"
+      
+      # Check that semver tag is greater than the github release version
+      PYPROJECT_GREATER_THAN_GITHUB_RELEASE=$(python -c "from packaging.version import Version; print(Version('${PYPROJECT_VERSION}') > Version('${GITHUB_RELEASE_VERSION}'))")
+
+      if [[ PYPROJECT_GREATER_THAN_GITHUB_RELEASE ]]; then
+        echo "The pyproject.toml version is greater than the latest GitHub release."
+      else
+        echo "The pyproject.toml version is not greater than the latest GitHub release."
+        exit 1
+      fi

--- a/.github/actions/check-version-release/action.yml
+++ b/.github/actions/check-version-release/action.yml
@@ -25,8 +25,9 @@ runs:
       
       # Check that semver tag is greater than the github release version
       PYPROJECT_EQUALS_GITHUB_RELEASE=$(python -c "from packaging.version import Version; print(Version('${PYPROJECT_VERSION}') == Version('${GITHUB_RELEASE_VERSION}'))")
+      echo "PYPROJECT_EQUALS_GITHUB_RELEASE=${PYPROJECT_EQUALS_GITHUB_RELEASE}"
 
-      if [[ PYPROJECT_EQUALS_GITHUB_RELEASE == "True" ]]; then
+      if $PYPROJECT_EQUALS_GITHUB_RELEASE; then
         echo "The pyproject.toml version is equal to the latest GitHub release."
       else
         echo "The pyproject.toml version is not equal to the the latest GitHub release."

--- a/.github/actions/check-version-release/action.yml
+++ b/.github/actions/check-version-release/action.yml
@@ -26,7 +26,7 @@ runs:
       # Check that semver tag is greater than the github release version
       PYPROJECT_EQUALS_GITHUB_RELEASE=$(python -c "from packaging.version import Version; print(Version('${PYPROJECT_VERSION}') == Version('${GITHUB_RELEASE_VERSION}'))")
 
-      if [[ PYPROJECT_EQUALS_GITHUB_RELEASE ]]; then
+      if [[ PYPROJECT_EQUALS_GITHUB_RELEASE == "True" ]]; then
         echo "The pyproject.toml version is equal to the latest GitHub release."
       else
         echo "The pyproject.toml version is not equal to the the latest GitHub release."

--- a/.github/actions/check-version-release/action.yml
+++ b/.github/actions/check-version-release/action.yml
@@ -1,5 +1,5 @@
 name: check-pyproject-version
-description: Check that the pyproject.toml version is greater than the latest GitHub release
+description: Check that the pyproject.toml version is the same as the latest GitHub release
 
 runs:
   using: composite
@@ -24,11 +24,11 @@ runs:
       echo "GITHUB_RELEASE_VERSION=${GITHUB_RELEASE_VERSION}"
       
       # Check that semver tag is greater than the github release version
-      PYPROJECT_GREATER_THAN_GITHUB_RELEASE=$(python -c "from packaging.version import Version; print(Version('${PYPROJECT_VERSION}') > Version('${GITHUB_RELEASE_VERSION}'))")
+      PYPROJECT_EQUALS_GITHUB_RELEASE=$(python -c "from packaging.version import Version; print(Version('${PYPROJECT_VERSION}') == Version('${GITHUB_RELEASE_VERSION}'))")
 
-      if [[ PYPROJECT_GREATER_THAN_GITHUB_RELEASE ]]; then
-        echo "The pyproject.toml version is greater than the latest GitHub release."
+      if [[ PYPROJECT_EQUALS_GITHUB_RELEASE ]]; then
+        echo "The pyproject.toml version is equal to the latest GitHub release."
       else
-        echo "The pyproject.toml version is not greater than the latest GitHub release."
+        echo "The pyproject.toml version is not equal to the the latest GitHub release."
         exit 1
       fi

--- a/.github/actions/check-version/action.yml
+++ b/.github/actions/check-version/action.yml
@@ -25,8 +25,9 @@ runs:
       
       # Check that semver tag is greater than the github release version
       PYPROJECT_GREATER_THAN_GITHUB_RELEASE=$(python -c "from packaging.version import Version; print(Version('${PYPROJECT_VERSION}') > Version('${GITHUB_RELEASE_VERSION}'))")
+      echo "PYPROJECT_GREATER_THAN_GITHUB_RELEASE=${PYPROJECT_GREATER_THAN_GITHUB_RELEASE}"
 
-      if [[ PYPROJECT_GREATER_THAN_GITHUB_RELEASE == "True" ]]; then
+      if $PYPROJECT_GREATER_THAN_GITHUB_RELEASE; then
         echo "The pyproject.toml version is greater than the latest GitHub release."
       else
         echo "The pyproject.toml version is not greater than the latest GitHub release."

--- a/.github/actions/check-version/action.yml
+++ b/.github/actions/check-version/action.yml
@@ -26,7 +26,7 @@ runs:
       # Check that semver tag is greater than the github release version
       PYPROJECT_GREATER_THAN_GITHUB_RELEASE=$(python -c "from packaging.version import Version; print(Version('${PYPROJECT_VERSION}') > Version('${GITHUB_RELEASE_VERSION}'))")
 
-      if [[ PYPROJECT_GREATER_THAN_GITHUB_RELEASE ]]; then
+      if [[ PYPROJECT_GREATER_THAN_GITHUB_RELEASE == "True" ]]; then
         echo "The pyproject.toml version is greater than the latest GitHub release."
       else
         echo "The pyproject.toml version is not greater than the latest GitHub release."

--- a/.github/actions/check-version/action.yml
+++ b/.github/actions/check-version/action.yml
@@ -27,7 +27,7 @@ runs:
       PYPROJECT_GREATER_THAN_GITHUB_RELEASE=$(python -c "from packaging.version import Version; print(Version('${PYPROJECT_VERSION}') > Version('${GITHUB_RELEASE_VERSION}'))")
       echo "PYPROJECT_GREATER_THAN_GITHUB_RELEASE=${PYPROJECT_GREATER_THAN_GITHUB_RELEASE}"
 
-      if $PYPROJECT_GREATER_THAN_GITHUB_RELEASE; then
+      if [[ PYPROJECT_GREATER_THAN_GITHUB_RELEASE ]]; then
         echo "The pyproject.toml version is greater than the latest GitHub release."
       else
         echo "The pyproject.toml version is not greater than the latest GitHub release."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Build 
         run: |
           poetry build 
-      
+
       - name: Publish 
         run: |
           poetry publish --username __token__ --password ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,10 +3,6 @@ on:
   release:
     types:
       - published
-  # TODO REMOVE AFTER TESTING 
-  pull_request:
-    branches:
-      - main
 
 jobs:
   precommit-checks:
@@ -70,7 +66,6 @@ jobs:
         run: |
           poetry build 
       
-      # TODO REMOVE AFTER TESTING 
-      # - name: Publish 
-      #   run: |
-      #     poetry publish --username __token__ --password ${{ secrets.PYPI_TOKEN }}
+      - name: Publish 
+        run: |
+          poetry publish --username __token__ --password ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,10 @@ on:
   release:
     types:
       - published
+  # TODO REMOVE AFTER TESTING 
+  pull_request:
+    branches:
+      - main
 
 jobs:
   precommit-checks:
@@ -65,7 +69,8 @@ jobs:
       - name: Build 
         run: |
           poetry build 
-
-      - name: Publish 
-        run: |
-          poetry publish --username __token__ --password ${{ secrets.PYPI_TOKEN }}
+      
+      # TODO REMOVE AFTER TESTING 
+      # - name: Publish 
+      #   run: |
+      #     poetry publish --username __token__ --password ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/checkout@v4
    
     - name: Run package version checks
-      uses: ./.github/actions/check-version
+      uses: ./.github/actions/check-version-release
 
   test:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ readme = "README.md"
 packages = [{include = "cpr_sdk", from = "src"}]
 classifiers = [
     "Intended Audience :: Science/Research",
-    "License :: BSD 3-Clause License",
+    "License :: OSI Approved :: BSD 3-Clause License",
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
-_MAJOR = "0"
-_MINOR = "5"
-_PATCH = "9"
+_MAJOR = "1"
+_MINOR = "0"
+_PATCH = "1"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)


### PR DESCRIPTION
# Description

- Updates the publish workflow to check that the version in the latest release matches that which is declared in the version.py module of the cpr_sdk package. This means that we can't publish a package that states a certain version in pypi whilst the python code references another version. 

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [x] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change

## How Has This Been Tested?

- The command has been run locally.
- I've triggered the workflows and observed the expected failures due to version disparity. 

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
