### PR TITLE
Adding method to the ParserOutput object to get row wise json.

### DIFF
--- a/src/cpr_sdk/parser_models.py
+++ b/src/cpr_sdk/parser_models.py
@@ -382,6 +382,10 @@ class ParserOutput(BaseParserOutput):
         In passage-level format we have a row for every text block in the document. This
         is as for natural language processing tasks we often want to work with text at
         the passage level.
+
+        HTML data won't contain PDF fields and vice versa, thus we must fill this in.
+        We could rely on the hugging face dataset transformation to fill in the missing
+        fields, but this is more explicit and provides default values.
         """
         if self.text_blocks is None:
             return []
@@ -400,9 +404,6 @@ class ParserOutput(BaseParserOutput):
             for idx, block in enumerate(self.text_blocks)
         ]
 
-        # HTML data won't contain PDF fields and vice versa, thus we must fill this in.
-        # We could rely on the hugging face dataset transformation to fill in the
-        # missing fields, but this is more explicit and provides default values.
         class BlockIndex:
             default = None
 

--- a/src/cpr_sdk/parser_models.py
+++ b/src/cpr_sdk/parser_models.py
@@ -432,4 +432,4 @@ class ParserOutput(BaseParserOutput):
                     passage[key] = empty_pdf_text_block[key]
             passages_array_filled.append(passage)
 
-        return passages_array
+        return passages_array_filled

--- a/src/cpr_sdk/parser_models.py
+++ b/src/cpr_sdk/parser_models.py
@@ -411,37 +411,17 @@ class ParserOutput(BaseParserOutput):
             for idx, block in enumerate(self.text_blocks)
         ]
 
-        empty_html_text_block: dict[str, Any] = json.loads(
-            HTMLTextBlock.model_validate(
-                {
-                    "text": [],
-                    "text_block_id": "",
-                    "type": BlockType.TEXT,
-                    "type_confidence": 1.0,
-                }
-            ).model_dump_json()
-        )
-        empty_pdf_text_block: dict[str, Any] = json.loads(
-            PDFTextBlock.model_validate(
-                {
-                    "text": [],
-                    "text_block_id": "",
-                    "type": BlockType.TEXT,
-                    "type_confidence": 1.0,
-                    "coords": [],
-                    "page_number": 0,
-                }
-            ).model_dump_json()
-        )
+        empty_html_text_block_keys: list[str] = list(HTMLTextBlock.model_fields.keys())
+        empty_pdf_text_block_keys: list[str] = list(PDFTextBlock.model_fields.keys())
 
         passages_array_filled = []
         for passage in passages_array:
-            for key in empty_html_text_block.keys():
+            for key in empty_html_text_block_keys:
                 if key not in passage:
-                    passage[key] = empty_html_text_block[key]
-            for key in empty_pdf_text_block.keys():
+                    passage[key] = None
+            for key in empty_pdf_text_block_keys:
                 if key not in passage:
-                    passage[key] = empty_pdf_text_block[key]
+                    passage[key] = None
             passages_array_filled.append(passage)
 
         return passages_array_filled

--- a/src/cpr_sdk/parser_models.py
+++ b/src/cpr_sdk/parser_models.py
@@ -4,7 +4,7 @@ from collections import Counter
 from datetime import date
 from enum import Enum
 from typing import List, Optional, Sequence, Tuple, TypeVar, Union, Any
-from pydantic_core.core_schema import PydanticUndefined
+from pydantic_core._pydantic_core import PydanticUndefined
 
 from cpr_sdk.pipeline_general_models import (
     CONTENT_TYPE_HTML,

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
-_MINOR = "0"
-_PATCH = "2"
+_MINOR = "1"
+_PATCH = "0"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)

--- a/tests/test_parser_models.py
+++ b/tests/test_parser_models.py
@@ -6,6 +6,8 @@ from cpr_sdk.parser_models import (
     ParserOutput,
     PDFTextBlock,
     VerticalFlipError,
+    HTMLTextBlock,
+    TextBlock
 )
 from cpr_sdk.pipeline_general_models import CONTENT_TYPE_HTML, CONTENT_TYPE_PDF
 
@@ -158,12 +160,26 @@ def test_to_passage_level_json_method(
     for parser_output_json in [parser_output_json_pdf, parser_output_json_html]:
         parser_output = ParserOutput.model_validate(parser_output_json)
         passage_level_array = parser_output.to_passage_level_json()
+
         assert isinstance(passage_level_array, list)
         assert len(passage_level_array) > 0
         assert len(passage_level_array) == len(parser_output.text_blocks)
         assert all(isinstance(passage, dict) for passage in passage_level_array)
-        # TODO Check that all the keys are correct
+
         first_doc_keys = set(passage_level_array[0].keys())
         assert all(
             set(passage.keys()) == first_doc_keys for passage in passage_level_array
+        )
+
+        expected_model_fields = set(
+            list(TextBlock.model_fields.keys())
+            + list(HTMLTextBlock.model_fields.keys())
+            + list(PDFTextBlock.model_fields.keys())
+            + list(ParserOutput.model_fields.keys())
+            + ["block_index"]
+        )
+
+        assert all(
+            set(passage.keys()) == expected_model_fields
+            for passage in passage_level_array
         )

--- a/tests/test_parser_models.py
+++ b/tests/test_parser_models.py
@@ -157,13 +157,16 @@ def test_to_passage_level_json_method(
     parser_output_json_html: dict,
 ) -> None:
     """Test that we can successfully create a passage level array from the text blocks."""
-    for parser_output_json in [parser_output_json_pdf, parser_output_json_html]:
-        parser_output = ParserOutput.model_validate(parser_output_json)
-        passage_level_array = parser_output.to_passage_level_json()
+    parser_output_pdf = ParserOutput.model_validate(parser_output_json_pdf)
+    passage_level_array_pdf = parser_output_pdf.to_passage_level_json()
 
-        assert isinstance(passage_level_array, list)
-        assert len(passage_level_array) > 0
-        assert len(passage_level_array) == len(parser_output.text_blocks)
+    parser_output_html = ParserOutput.model_validate(parser_output_json_html)
+    passage_level_array_html = parser_output_html.to_passage_level_json()
+
+    assert len(passage_level_array_pdf) == len(parser_output_pdf.text_blocks)
+    assert len(passage_level_array_html) == len(parser_output_html.text_blocks)
+
+    for passage_level_array in [passage_level_array_pdf, passage_level_array_html]:
         assert all(isinstance(passage, dict) for passage in passage_level_array)
 
         first_doc_keys = set(passage_level_array[0].keys())
@@ -183,3 +186,11 @@ def test_to_passage_level_json_method(
             set(passage.keys()) == expected_model_fields
             for passage in passage_level_array
         )
+
+    passage_level_array_pdf_first_doc = passage_level_array_pdf[0]
+    passage_level_array_html_first_doc = passage_level_array_html[0]
+
+    assert (
+        passage_level_array_pdf_first_doc.keys()
+        == passage_level_array_html_first_doc.keys()
+    )

--- a/tests/test_parser_models.py
+++ b/tests/test_parser_models.py
@@ -7,7 +7,7 @@ from cpr_sdk.parser_models import (
     PDFTextBlock,
     VerticalFlipError,
     HTMLTextBlock,
-    TextBlock
+    TextBlock,
 )
 from cpr_sdk.pipeline_general_models import CONTENT_TYPE_HTML, CONTENT_TYPE_PDF
 


### PR DESCRIPTION
# Description

- This update includes a new method on the `ParserOutput` model to convert the object to a row wise object where there is a row for each text block. 
- This is to support work in the data sync to hugging face push that requires this format. 

The fields for the passage level rows in the array that is produced from the method are as follows: 

_These are effectively the top level `ParserOutput` fields as well as the `PDFTextBlock` and `HTMLTextBlock` fields._ 

```python
{'document_cdn_object', 'languages', 'document_name', 'pdf_data', 'document_content_type', 'block_index', 'document_id', 'page_number', 'type', 'translated', 'language', 'document_source_url', 'document_slug', 'type_confidence', 'html_data', 'document_description', 'document_metadata', 'pipeline_metadata', 'text_block_id', 'text', 'coords', 'document_md5_sum'}
```
The plan is then to `flatten` the dataset using huggingface in the `navigator_data_sync` such that nested fields like `document_metadata` are readable. 

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [X] Minor version
- [ ] Major version

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## How Has This Been Tested?

- New unit tests. 

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [X] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [X] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [X] If this PR fixes a bug, I've added a test that will fail without my fix.
- [X] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
