### PR TITLE
Updating the conditional of whether to assign a page number.

### DIFF
--- a/src/cpr_sdk/parser_models.py
+++ b/src/cpr_sdk/parser_models.py
@@ -415,10 +415,10 @@ class ParserOutput(BaseParserOutput):
         ]
 
         for passage in passages_array:
-            page_number = passage.get("page_number")
+            page_number = passage.get("page_number", None)
             passage[PDF_PAGE_METADATA_KEY] = (
                 self.get_page_metadata_by_page_number(page_number)
-                if page_number
+                if page_number is not None
                 else None
             )
 

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
 _MINOR = "1"
-_PATCH = "4"
+_PATCH = "5"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)

--- a/tests/test_parser_models.py
+++ b/tests/test_parser_models.py
@@ -204,6 +204,7 @@ def test_to_passage_level_json_method(
             )
 
             if passage["document_content_type"] == CONTENT_TYPE_PDF:
+                assert passage[PDF_PAGE_METADATA_KEY] is not None
                 assert set(passage["pdf_data"].keys()) == expected_pdf_data_fields
             elif passage["document_content_type"] == CONTENT_TYPE_HTML:
                 assert set(passage["html_data"].keys()) == expected_html_data_fields


### PR DESCRIPTION
# Description

This is a bug fix for the passage level hugging face dataset. Noticed that the text blocks corresponding to the first page didn't have pdf metadata assigned. 

Upon inspection of the code realised that the conditional that was used was skipping 0. 

This can be proven by: 

```python
>>> page_number = 0 
>>> if page_number:
...     print("hello world")
... 
>>> 
```

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [X] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Used TDD to add a failing test and then a fix. 

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [X] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [X] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [X] If this PR fixes a bug, I've added a test that will fail without my fix.
- [X] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
