### PR TITLE
Feature/pdct 859 500 docs appear in a search

### DIFF
--- a/src/cpr_sdk/models/search.py
+++ b/src/cpr_sdk/models/search.py
@@ -73,11 +73,12 @@ class SearchParameters(BaseModel):
     exact_match: bool = False
     all_results: bool = False
     documents_only: bool = False
-    limit: int = Field(ge=0, default=100)
+    limit: int = Field(ge=0, default=100, le=500)
     max_hits_per_family: int = Field(
         validation_alias=AliasChoices("max_passages_per_doc", "max_hits_per_family"),
         default=10,
         ge=0,
+        le=500
     )
 
     family_ids: Optional[Sequence[str]] = None

--- a/src/cpr_sdk/models/search.py
+++ b/src/cpr_sdk/models/search.py
@@ -70,29 +70,79 @@ class SearchParameters(BaseModel):
     """Parameters for a search request"""
 
     query_string: Optional[str] = ""
+    """
+    A string representation of the search to be performed.
+    For example: 'Adaptation strategy'"
+    """
+    
     exact_match: bool = False
+    """
+    Indicate if the `query_string` should be treated as an exact match when 
+    the search is performed.
+    """
+    
     all_results: bool = False
+    """
+    Return all results rather than searching or ranking
+    
+    Filters can still be applied
+    """
+
     documents_only: bool = False
+    """Ignores passages in search when true."""
+
     limit: int = Field(ge=0, default=100, le=500)
+    """
+    Refers to the maximum number of results to return from the "
+    query result.
+    """
+    
     max_hits_per_family: int = Field(
         validation_alias=AliasChoices("max_passages_per_doc", "max_hits_per_family"),
         default=10,
         ge=0,
         le=500
     )
+    """
+    The maximum number of matched passages to be returned for a "
+    single document.
+    """
 
     family_ids: Optional[Sequence[str]] = None
+    """Optionally limit a search to a specific set of family ids."""
+    
     document_ids: Optional[Sequence[str]] = None
+    """Optionally limit a search to a specific set of document ids."""
 
     filters: Optional[Filters] = None
-    year_range: Optional[tuple[Optional[int], Optional[int]]] = None
+    """Filter results to matching filter items."""
 
+    year_range: Optional[tuple[Optional[int], Optional[int]]] = None
+    """
+    The years to search between. Containing exactly two values,
+    which can be null or an integer representing the years to
+    search between. These are inclusive and can be null. Example:
+    [null, 2010] will return all documents return in or before 2010.
+    """
+    
     sort_by: Optional[str] = Field(
         validation_alias=AliasChoices("sort_field", "sort_by"), default=None
     )
+    """The field to sort by can be chosen from `date` or `title`."""
+
     sort_order: str = "descending"
+    """
+    The order of the results according to the `sort_field`, can be chosen from
+    ascending (use “asc”) or descending (use “desc”).
+    """
 
     continuation_tokens: Optional[Sequence[str]] = None
+    """
+    Use to return the next page of results from a specific search, the next token
+    can be found on the response object. It's also possible to get the next page
+    of passages by including the family level continuation token first in the 
+    array followed by the passage level one.
+    """
 
     @model_validator(mode="after")
     def validate(self):

--- a/src/cpr_sdk/search_adaptors.py
+++ b/src/cpr_sdk/search_adaptors.py
@@ -1,4 +1,5 @@
 """Adaptors for searching CPR data"""
+
 import time
 from abc import ABC
 from pathlib import Path

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
 _MINOR = "1"
-_PATCH = "5"
+_PATCH = "6"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,9 +23,8 @@ def test_vespa():
         adaptor = VespaSearchAdapter(
             instance_url=VESPA_TEST_SEARCH_URL, cert_directory=tmpdir_cert_dir
         )
-    
-        yield adaptor
 
+        yield adaptor
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,18 +6,26 @@ import pytest
 import boto3
 from moto import mock_aws
 
+from cpr_sdk.search_adaptors import VespaSearchAdapter
+
 
 VESPA_TEST_SEARCH_URL = "http://localhost:8080"
 
 
 @pytest.fixture()
-def fake_vespa_credentials():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        with open(Path(tmpdir) / "cert.pem", "w"):
+def test_vespa():
+    """Vespa adapter pointing to test url and using empty cert files"""
+    with tempfile.TemporaryDirectory() as tmpdir_cert_dir:
+        with open(Path(tmpdir_cert_dir) / "cert.pem", "w"):
             pass
-        with open(Path(tmpdir) / "key.pem", "w"):
+        with open(Path(tmpdir_cert_dir) / "key.pem", "w"):
             pass
-        yield tmpdir
+        adaptor = VespaSearchAdapter(
+            instance_url=VESPA_TEST_SEARCH_URL, cert_directory=tmpdir_cert_dir
+        )
+    
+        yield adaptor
+
 
 
 @pytest.fixture()

--- a/tests/test_search_adaptors.py
+++ b/tests/test_search_adaptors.py
@@ -185,7 +185,7 @@ def test_vespa_search_adaptor__sensitive(test_vespa):
         (1, 100),
         (2, 1),
         (2, 5),
-        (3, 1000),
+        (3, 500),
     ],
 )
 @pytest.mark.vespa
@@ -201,6 +201,24 @@ def test_vespa_search_adaptor__limits(test_vespa, family_limit, max_hits_per_fam
     assert len(response.families) == family_limit
     for fam in response.families:
         assert len(fam.hits) <= max_hits_per_family
+
+
+@pytest.mark.parametrize(
+    "family_limit, max_hits_per_family",
+    [
+        (501, 5),
+        (3, 501),
+    ],
+)
+@pytest.mark.vespa
+def test_vespa_search_adaptor__limits__errors(family_limit, max_hits_per_family):
+    with pytest.raises(ValueError):
+        SearchParameters(
+            query_string="the",
+            family_ids=[],
+            limit=family_limit,
+            max_hits_per_family=max_hits_per_family,
+        )
 
 
 @pytest.mark.vespa

--- a/tests/test_search_requests.py
+++ b/tests/test_search_requests.py
@@ -3,7 +3,6 @@ import re
 
 import pytest
 from cpr_sdk.embedding import Embedder
-from cpr_sdk.exceptions import QueryError
 from cpr_sdk.models.search import (
     Filters,
     SearchParameters,
@@ -57,9 +56,8 @@ def test_whether_an_empty_query_string_does_all_result_search():
 
 def test_wether_documents_only_without_all_results_raises_error():
     q = "Search"
-    with pytest.raises(QueryError) as excinfo:
+    with pytest.raises(ValidationError) as excinfo:
         SearchParameters(query_string=q, documents_only=True)
-    assert "Failed to build query" in str(excinfo.value)
     assert "`documents_only` requires `all_results`" in str(excinfo.value)
 
     # They should be fine otherwise:
@@ -71,9 +69,8 @@ def test_wether_documents_only_without_all_results_raises_error():
 
 def test_wether_combining_all_results_and_exact_match_raises_error():
     q = "Search"
-    with pytest.raises(QueryError) as excinfo:
+    with pytest.raises(ValidationError) as excinfo:
         SearchParameters(query_string=q, exact_match=True, all_results=True)
-    assert "Failed to build query" in str(excinfo.value)
     assert "`exact_match` and `all_results`" in str(excinfo.value)
 
     # They should be fine independently:
@@ -102,8 +99,8 @@ def test_whether_valid_year_ranges_are_accepted(year_range):
     assert isinstance(params, SearchParameters)
 
 
-def test_whether_an_invalid_year_range_ranges_raises_a_queryerror():
-    with pytest.raises(QueryError) as excinfo:
+def test_whether_an_invalid_year_range_ranges_raises_a_validation_error():
+    with pytest.raises(ValidationError) as excinfo:
         SearchParameters(query_string="test", year_range=(2023, 2000))
     assert (
         "The first supplied year must be less than or equal to the second supplied year"
@@ -129,8 +126,8 @@ def test_whether_valid_family_ids_are_accepted():
         "UNFCCC.family.i00000003.n000.11",
     ],
 )
-def test_whether_an_invalid_family_id_raises_a_queryerror(bad_id):
-    with pytest.raises(QueryError) as excinfo:
+def test_whether_an_invalid_family_id_raises_a_validation_error(bad_id):
+    with pytest.raises(ValidationError) as excinfo:
         SearchParameters(
             query_string="test",
             family_ids=("CCLW.family.i00000003.n0000", bad_id),
@@ -157,8 +154,8 @@ def test_whether_valid_document_ids_are_accepted():
         "UNFCCC.doc.i00000003",
     ],
 )
-def test_whether_an_invalid_document_id_raises_a_queryerror(bad_id):
-    with pytest.raises(QueryError) as excinfo:
+def test_whether_an_invalid_document_id_raises_a_validation_error(bad_id):
+    with pytest.raises(ValidationError) as excinfo:
         SearchParameters(
             query_string="test",
             document_ids=(bad_id, "CCLW.document.i00000004.n0000"),
@@ -174,8 +171,8 @@ def test_whether_valid_sort_fields_are_accepted(field):
     assert isinstance(params, SearchParameters)
 
 
-def test_whether_an_invalid_sort_field_raises_a_queryerror():
-    with pytest.raises(QueryError) as excinfo:
+def test_whether_an_invalid_sort_field_raises_a_validation_error():
+    with pytest.raises(ValidationError) as excinfo:
         SearchParameters(query_string="test", sort_by="invalid_field")
     assert "sort_by must be one of" in str(excinfo.value)
 
@@ -186,8 +183,8 @@ def test_whether_valid_sort_orders_are_accepted(order):
     assert isinstance(params, SearchParameters)
 
 
-def test_whether_an_invalid_sort_order_raises_a_queryerror():
-    with pytest.raises(QueryError) as excinfo:
+def test_whether_an_invalid_sort_order_raises_a_validation_error():
+    with pytest.raises(ValidationError) as excinfo:
         SearchParameters(query_string="test", sort_order="invalid_order")
     assert "sort_order must be one of" in str(excinfo.value)
 
@@ -249,10 +246,10 @@ def test_whether_an_invalid_filter_fields_value_fixes_it_silently(
     (
         (["", None], ValidationError),
         ([123], ValidationError),
-        (["123"], QueryError),
-        (["!@$"], QueryError),
-        (["lower"], QueryError),
-        (["", "lower"], QueryError),
+        (["123"], ValidationError),
+        (["!@$"], ValidationError),
+        (["lower"], ValidationError),
+        (["", "lower"], ValidationError),
     ),
 )
 def test_continuation_tokens__bad(tokens, error):


### PR DESCRIPTION
# Description

This is the sdk requirements to resolve the following:
- Upper limit on search page sizes ([docs](https://linear.app/climate-policy-radar/issue/PDCT-1199/allow-search-data-model-to-accept-a-maximum-passage-matches-to-500), [passages](https://linear.app/climate-policy-radar/issue/PDCT-1199/allow-search-data-model-to-accept-a-maximum-passage-matches-to-500))
- Fix [uncaught query errors](https://linear.app/climate-policy-radar/issue/PDCT-1117/searches-endpoint-returns-500-due-to-continuation-tokens)
- [Move search request documentation to the sdk](https://github.com/climatepolicyradar/navigator-backend/blob/main/app/api/api_v1/schemas/search.py#L125)

Also fixes a profiling test issue where the time included the adapter instantiation time unnecessarily.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
