### PR TITLE
Add model methods to match backend duplicate model

### DIFF
--- a/src/cpr_sdk/pipeline_general_models.py
+++ b/src/cpr_sdk/pipeline_general_models.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Mapping, Any, List, Optional, Sequence, Union
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, field_validator, model_validator
 
 Json = dict[str, Any]
 
@@ -53,6 +53,21 @@ class BackendDocument(BaseModel):
         self.date = self.publication_ts.strftime("%d/%m/%Y")
 
         return self
+
+    @field_validator("type", mode="before")
+    @classmethod
+    def none_to_empty_string(cls, value):
+        """If the value is None, will convert to an empty string"""
+        return "" if value is None else value
+
+    def to_json(self) -> Mapping[str, Any]:
+        """Provide a serialisable version of the model"""
+
+        json_dict = self.model_dump()
+        json_dict["publication_ts"] = (
+            self.publication_ts.isoformat() if self.publication_ts is not None else None
+        )
+        return json_dict
 
 
 class InputData(BaseModel):

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,5 +1,5 @@
 _MAJOR = "1"
-_MINOR = "1"
+_MINOR = "2"
 _PATCH = "10"
 _SUFFIX = ""
 


### PR DESCRIPTION
The backend has an identical version of this model except for the additional methods. This makes it so we'll be able to switch out the backend model for this one (and therefore only update in one place)

# Description

Please include:

- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
