### PR TITLE
Remove obsolete date field assignment 

### DIFF
--- a/src/cpr_sdk/pipeline_general_models.py
+++ b/src/cpr_sdk/pipeline_general_models.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Mapping, Any, List, Optional, Sequence, Union
 
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import BaseModel, field_validator
 
 Json = dict[str, Any]
 
@@ -29,7 +29,7 @@ class BackendDocument(BaseModel):
     family_import_id: str
     family_slug: str
     publication_ts: datetime
-    date: Optional[str] = None  # Set on import by a validator
+    date: Optional[str] = None
     source_url: Optional[str] = None
     download_url: Optional[str] = None
     corpus_import_id: Optional[str] = None
@@ -44,20 +44,6 @@ class BackendDocument(BaseModel):
     languages: Sequence[str]
 
     metadata: Json
-
-    @model_validator(mode="after")
-    def convert_publication_ts_to_date(self):
-        """
-        Convert publication_ts to a datetime string.
-
-        This is necessary as OpenSearch expects a date object.
-
-        TODO: remove when no longer using Opensearch
-        """
-
-        self.date = self.publication_ts.strftime("%d/%m/%Y")
-
-        return self
 
     @field_validator("type", mode="before")
     @classmethod

--- a/src/cpr_sdk/pipeline_general_models.py
+++ b/src/cpr_sdk/pipeline_general_models.py
@@ -29,7 +29,7 @@ class BackendDocument(BaseModel):
     family_import_id: str
     family_slug: str
     publication_ts: datetime
-    date: Optional[str] = None
+    date: Optional[str] = None  # Deprecated
     source_url: Optional[str] = None
     download_url: Optional[str] = None
     corpus_import_id: Optional[str] = None

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
 _MINOR = "3"
-_PATCH = "10"
+_PATCH = "11"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)


### PR DESCRIPTION
We no longer have opensearch, so this is not needed. I have looked in the backend and through the pipeline and can't find any instances of it still being used. I've also left the field itself so it can still be used if we have any more-legacy type code lying around

# Description

Please include:

- a summary of the changes
- links to any related issue/ticket
- any additional relevant motivation and context
- details of any dependency updates that are required for this change

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
