### PR TITLE
Fix warnings

### DIFF
--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
 _MINOR = "3"
-_PATCH = "11"
+_PATCH = "12"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)

--- a/tests/local_vespa/docker-compose.dev.yml
+++ b/tests/local_vespa/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   vespadaltest:
     image: vespaengine/vespa:8.396.18

--- a/tests/local_vespa/test_app/schemas/document_passage.sd
+++ b/tests/local_vespa/test_app/schemas/document_passage.sd
@@ -64,7 +64,7 @@ schema document_passage {
     import field search_weights_ref.passage_weight as passage_weight {}
 
     fieldset default {
-        fields: text_block, text_embedding
+        fields: text_block
     }
 
     document-summary search_summary {

--- a/tests/local_vespa/test_app/schemas/document_passage.sd
+++ b/tests/local_vespa/test_app/schemas/document_passage.sd
@@ -68,25 +68,25 @@ schema document_passage {
     }
 
     document-summary search_summary {
-        summary family_name type string {}
-        summary family_description type string {}
-        summary family_import_id type string {}
-        summary family_slug type string {}
-        summary family_category type string {}
-        summary family_publication_ts type string {}
-        summary family_geography type string {}
-        summary family_source type string {}
-        summary document_import_id type string {}
-        summary document_slug type string {}
-        summary document_languages type array<string> {}
-        summary document_content_type type string {}
-        summary document_cdn_object type string {}
-        summary document_source_url type string {}
-        summary text_block type string {}
-        summary text_block_id type string {}
-        summary text_block_type type string {}
-        summary text_block_page type int {}
-        summary text_block_coords type array<array<float>> {}
+        summary family_name {}
+        summary family_description {}
+        summary family_import_id {}
+        summary family_slug {}
+        summary family_category {}
+        summary family_publication_ts {}
+        summary family_geography {}
+        summary family_source {}
+        summary document_import_id {}
+        summary document_slug {}
+        summary document_languages {}
+        summary document_content_type {}
+        summary document_cdn_object {}
+        summary document_source_url {}
+        summary text_block {}
+        summary text_block_id {}
+        summary text_block_type {}
+        summary text_block_page {}
+        summary text_block_coords {}
     }
 
     rank-profile exact inherits default {

--- a/tests/local_vespa/test_app/schemas/family_document.sd
+++ b/tests/local_vespa/test_app/schemas/family_document.sd
@@ -155,7 +155,7 @@ schema family_document {
     import field search_weights_ref.description_weight as description_weight {}
 
     fieldset default {
-        fields: family_name_index, family_description_index, family_description_embedding
+        fields: family_name_index, family_description_index
     }
 
     rank-profile exact inherits default {


### PR DESCRIPTION
# Description

1. Remove obsolete 'version' from docker compose file
2. Remove embeddings from fieldset
    Deals with the error:
    ```
    WARNING For schema '...', fieldset 'default': Tensor fields ['...']
    cannot be mixed with non-tensor fields ['...'] in the same fieldset.
    See https://docs.vespa.ai/en/reference/schema-reference.html#fieldset
    ```
3. Remove obsolete type assignment for summaries
    Deals with the warning for each field:
    ```
    WARNING For schema '...', summary field '...': Specifying the type is
    deprecated, ignored and will be an error in Vespa 9. Remove the type
    specification to silence this warning.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
