### PR TITLE
Integrate geographies filter 

### DIFF
--- a/src/cpr_sdk/models/search.py
+++ b/src/cpr_sdk/models/search.py
@@ -41,6 +41,7 @@ class Filters(BaseModel):
     """Filterable fields in a search request"""
 
     family_geography: Sequence[str] = []
+    family_geographies: Sequence[str] = []
     family_category: Sequence[str] = []
     document_languages: Sequence[str] = []
     family_source: Sequence[str] = []
@@ -50,7 +51,11 @@ class Filters(BaseModel):
     }
 
     @field_validator(
-        "family_geography", "family_category", "document_languages", "family_source"
+        "family_geographies",
+        "family_geography",
+        "family_category",
+        "document_languages",
+        "family_source",
     )
     def sanitise_filter_inputs(cls, field):
         """Remove problematic characters from filter values"""
@@ -263,6 +268,7 @@ class Hit(BaseModel):
     family_category: Optional[str] = None
     family_publication_ts: Optional[datetime] = None
     family_geography: Optional[str] = None
+    family_geographies: Optional[List[str]] = None
     document_import_id: Optional[str] = None
     document_slug: Optional[str] = None
     document_languages: Optional[List[str]] = None
@@ -324,6 +330,7 @@ class Document(Hit):
             family_category=fields.get("family_category"),
             family_publication_ts=family_publication_ts,
             family_geography=fields.get("family_geography"),
+            family_geographies=fields.get("family_geographies", []),
             document_import_id=fields.get("document_import_id"),
             document_slug=fields.get("document_slug"),
             document_languages=fields.get("document_languages", []),

--- a/src/cpr_sdk/yql_builder.py
+++ b/src/cpr_sdk/yql_builder.py
@@ -117,13 +117,15 @@ class YQLBuilder:
             return f"(document_import_id in({documents}))"
         return None
 
-    def _inclusive_filters(self, filters: Filters, field_name: str):
+    def _inclusive_filters(
+        self, filters: Filters, field_name: str, join_operator: str = "or"
+    ) -> Optional[str]:
         values = getattr(filters, field_name)
         query_filters = []
         for value in values:
             query_filters.append(f'({field_name} contains "{value}")')
         if query_filters:
-            return f"({' or '.join(query_filters)})"
+            return f"({f' {join_operator} '.join(query_filters)})"
 
     def build_year_start_filter(self) -> Optional[str]:
         """Create the part of the query that filters on a year range"""
@@ -150,13 +152,13 @@ class YQLBuilder:
         filters.append(self.build_corpus_filter())
         filters.append(self.build_metadata_filter())
         if f := self.params.filters:
+            filters.append(self._inclusive_filters(f, "family_geographies", "and"))
             filters.append(self._inclusive_filters(f, "family_geography"))
             filters.append(self._inclusive_filters(f, "family_category"))
             filters.append(self._inclusive_filters(f, "document_languages"))
             filters.append(self._inclusive_filters(f, "family_source"))
         filters.append(self.build_year_start_filter())
         filters.append(self.build_year_end_filter())
-
         return " and ".join([f for f in filters if f])  # Remove empty
 
     def build_continuation(self) -> str:

--- a/src/cpr_sdk/yql_builder.py
+++ b/src/cpr_sdk/yql_builder.py
@@ -130,15 +130,13 @@ class YQLBuilder:
             return f"(document_import_id in({documents}))"
         return None
 
-    def _inclusive_filters(
-        self, filters: Filters, field_name: str, join_operator: str = "or"
-    ) -> Optional[str]:
+    def _inclusive_filters(self, filters: Filters, field_name: str) -> Optional[str]:
         values = getattr(filters, field_name)
         query_filters = []
         for value in values:
             query_filters.append(f'({field_name} contains "{value}")')
         if query_filters:
-            return f"({f' {join_operator} '.join(query_filters)})"
+            return f"({' or '.join(query_filters)})"
 
     def build_year_start_filter(self) -> Optional[str]:
         """Create the part of the query that filters on a year range"""
@@ -166,7 +164,7 @@ class YQLBuilder:
         filters.append(self.build_corpus_import_ids_filter())
         filters.append(self.build_metadata_filter())
         if f := self.params.filters:
-            filters.append(self._inclusive_filters(f, "family_geographies", "and"))
+            filters.append(self._inclusive_filters(f, "family_geographies"))
             filters.append(self._inclusive_filters(f, "family_geography"))
             filters.append(self._inclusive_filters(f, "family_category"))
             filters.append(self._inclusive_filters(f, "document_languages"))

--- a/tests/local_vespa/test_documents/family_document.json
+++ b/tests/local_vespa/test_documents/family_document.json
@@ -10,7 +10,7 @@
       "family_slug": "climate-change-adaptation-and-low-emissions-growth-strategy-by-2035_75e3",
       "document_source_url": "https://unfccc.int/sites/default/files/resource/ENG_CC%20adaptation%20and%20Low%20emission%20development%20Strategy%20BiH%202020-2030.pdf",
       "family_geography": "BIH",
-      "family_geographies": ["BIH"],
+      "family_geographies": ["BIH", "NOR"],
       "family_category": "Executive",
       "family_name_index": "Climate Change Adaptation and Low Emissions Growth Strategy by 2035",
       "document_languages": ["English"],

--- a/tests/test_search_adaptors.py
+++ b/tests/test_search_adaptors.py
@@ -511,6 +511,8 @@ def test_vespa_search_adaptor__geographies(
     assert response_one.total_family_hits > 0
     for family in response_one.families:
         for hit in family.hits:
-            assert hit.family_geographies not in [[], None] and set(
-                ["BIH", "NOR"]
-            ) == set(hit.family_geographies)
+            assert (
+                hit.family_geographies not in [[], None]
+                and "BIH" in hit.family_geographies
+                and "NOR" in hit.family_geographies
+            )

--- a/tests/test_search_requests.py
+++ b/tests/test_search_requests.py
@@ -200,7 +200,7 @@ def test_computed_vespa_sort_fields(sort_by, sort_order):
 
 @pytest.mark.parametrize(
     "field",
-    ["family_geography", "family_category", "document_languages", "family_source"],
+    ["family_geographies", "family_geography", "family_category", "document_languages", "family_source"],
 )
 def test_whether_valid_filter_fields_are_accepted(field):
     filters = Filters(**{field: ["value"]})

--- a/tests/test_search_requests.py
+++ b/tests/test_search_requests.py
@@ -1,16 +1,12 @@
-from unittest.mock import patch
 import re
+from unittest.mock import patch
 
 import pytest
-from cpr_sdk.embedding import Embedder
-from cpr_sdk.models.search import (
-    Filters,
-    SearchParameters,
-    sort_fields,
-    sort_orders,
-)
-from cpr_sdk.vespa import build_vespa_request_body
 from pydantic import ValidationError
+
+from cpr_sdk.embedding import Embedder
+from cpr_sdk.models.search import Filters, SearchParameters, sort_fields, sort_orders
+from cpr_sdk.vespa import build_vespa_request_body
 
 
 @patch(
@@ -200,7 +196,13 @@ def test_computed_vespa_sort_fields(sort_by, sort_order):
 
 @pytest.mark.parametrize(
     "field",
-    ["family_geographies", "family_geography", "family_category", "document_languages", "family_source"],
+    [
+        "family_geographies",
+        "family_geography",
+        "family_category",
+        "document_languages",
+        "family_source",
+    ],
 )
 def test_whether_valid_filter_fields_are_accepted(field):
     filters = Filters(**{field: ["value"]})

--- a/tests/test_yql_builder.py
+++ b/tests/test_yql_builder.py
@@ -18,7 +18,7 @@ def test_whether_document_only_search_ignores_passages_in_yql():
 
 def test_whether_single_filter_values_and_lists_of_filter_values_appear_in_yql():
     filters = {
-        "family_geographies": ["SWE"],
+        "family_geographies": ["SWE", "USA"],
         "family_geography": ["SWE"],
         "family_category": ["Executive"],
         "document_languages": ["English", "Swedish"],

--- a/tests/test_yql_builder.py
+++ b/tests/test_yql_builder.py
@@ -1,13 +1,9 @@
 import pytest
-from cpr_sdk.models.search import (
-    Filters,
-    SearchParameters,
-    sort_fields,
-    sort_orders,
-)
+from vespa.exceptions import VespaError
+
+from cpr_sdk.models.search import Filters, SearchParameters, sort_fields, sort_orders
 from cpr_sdk.vespa import VespaErrorDetails
 from cpr_sdk.yql_builder import YQLBuilder
-from vespa.exceptions import VespaError
 
 
 def test_whether_document_only_search_ignores_passages_in_yql():

--- a/tests/test_yql_builder.py
+++ b/tests/test_yql_builder.py
@@ -22,6 +22,7 @@ def test_whether_document_only_search_ignores_passages_in_yql():
 
 def test_whether_single_filter_values_and_lists_of_filter_values_appear_in_yql():
     filters = {
+        "family_geographies": ["SWE"],
         "family_geography": ["SWE"],
         "family_category": ["Executive"],
         "document_languages": ["English", "Swedish"],


### PR DESCRIPTION
# Description

This pull request updates the `Filters` object and relating `YQL` and `query` code to enable filtering for `family_geographies`. 

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
