### PR TITLE
Allow VespaSearchAdaptor instantiation with no certs 

### DIFF
--- a/src/cpr_sdk/search_adaptors.py
+++ b/src/cpr_sdk/search_adaptors.py
@@ -1,24 +1,25 @@
 """Adaptors for searching CPR data"""
 
+import logging
 import time
 from abc import ABC
 from pathlib import Path
 from typing import Optional
-import logging
+
+from requests.exceptions import HTTPError
+from vespa.application import Vespa
+from vespa.exceptions import VespaError
 
 from cpr_sdk.embedding import Embedder
 from cpr_sdk.exceptions import DocumentNotFoundError, FetchError, QueryError
 from cpr_sdk.models.search import Hit, SearchParameters, SearchResponse
 from cpr_sdk.vespa import (
+    VespaErrorDetails,
     build_vespa_request_body,
     find_vespa_cert_paths,
     parse_vespa_response,
     split_document_id,
-    VespaErrorDetails,
 )
-from requests.exceptions import HTTPError
-from vespa.application import Vespa
-from vespa.exceptions import VespaError
 
 LOGGER = logging.getLogger(__name__)
 
@@ -67,10 +68,10 @@ class VespaSearchAdapter(SearchAdapter):
         if cert_directory is None:
             cert_path, key_path = find_vespa_cert_paths()
         else:
-            cert_path = Path(cert_directory) / "cert.pem"
-            key_path = Path(cert_directory) / "key.pem"
+            cert_path = (Path(cert_directory) / "cert.pem").__str__()
+            key_path = (Path(cert_directory) / "key.pem").__str__()
 
-        self.client = Vespa(url=instance_url, cert=str(cert_path), key=str(key_path))
+        self.client = Vespa(url=instance_url, cert=cert_path, key=key_path)
         self.embedder = embedder or Embedder()
 
     def search(self, parameters: SearchParameters) -> SearchResponse:

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
 _MINOR = "4"
-_PATCH = "2"
+_PATCH = "3"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)

--- a/src/cpr_sdk/vespa.py
+++ b/src/cpr_sdk/vespa.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, List, Union
+from typing import Any, List, Optional
 
 import yaml
 from vespa.exceptions import VespaError

--- a/src/cpr_sdk/vespa.py
+++ b/src/cpr_sdk/vespa.py
@@ -36,7 +36,7 @@ def split_document_id(document_id: str) -> tuple[str, str, str]:
     return namespace, schema, data_id
 
 
-def find_vespa_cert_paths() -> tuple[Union[str, None], Union[str, None]]:
+def find_vespa_cert_paths() -> tuple[Optional[str], Optional[str]]:
     """
     Automatically find the certificate and key files for the vespa instance
 

--- a/src/cpr_sdk/vespa.py
+++ b/src/cpr_sdk/vespa.py
@@ -54,6 +54,8 @@ def find_vespa_cert_paths() -> tuple[Optional[str], Optional[str]]:
     # read the config.yaml file to find the application name
     with open(vespa_directory / "config.yaml", "r", encoding="utf-8") as yaml_file:
         data = yaml.safe_load(yaml_file)
+        if "application" not in data:
+            return None, None
         application_name = data["application"]
 
     cert_directory = vespa_directory / application_name

--- a/src/cpr_sdk/vespa.py
+++ b/src/cpr_sdk/vespa.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, List
+from typing import Any, List, Union
 
 import yaml
 from vespa.exceptions import VespaError
@@ -36,7 +36,7 @@ def split_document_id(document_id: str) -> tuple[str, str, str]:
     return namespace, schema, data_id
 
 
-def find_vespa_cert_paths() -> tuple[Path, Path]:
+def find_vespa_cert_paths() -> tuple[Union[str, None], Union[str, None]]:
     """
     Automatically find the certificate and key files for the vespa instance
 
@@ -57,8 +57,16 @@ def find_vespa_cert_paths() -> tuple[Path, Path]:
         application_name = data["application"]
 
     cert_directory = vespa_directory / application_name
-    cert_path = list(cert_directory.glob("*cert.pem"))[0]
-    key_path = list(cert_directory.glob("*key.pem"))[0]
+
+    cert_directory_certs = list(cert_directory.glob("*cert.pem"))
+    cert_path = (
+        str(list(cert_directory.glob("*cert.pem"))[0]) if cert_directory_certs else None
+    )
+    cert_directory_keys = list(cert_directory.glob("*key.pem"))
+    key_path = (
+        str(list(cert_directory.glob("*key.pem"))[0]) if cert_directory_keys else None
+    )
+
     return cert_path, key_path
 
 

--- a/tests/test_search_adaptors.py
+++ b/tests/test_search_adaptors.py
@@ -37,6 +37,18 @@ def profile_search(
     return avg_ms
 
 
+@pytest.mark.parametrize(
+    "search_adaptor_params",
+    [
+        {"instance_url": "http://localhost:8080", "cert_directory": "/tmp"},
+        {"instance_url": "http://localhost:8080"},
+    ],
+)
+@pytest.mark.vespa
+def test_vespa_search_adaptor_instantiation(search_adaptor_params: dict) -> None:
+    VespaSearchAdapter(**search_adaptor_params)
+
+
 @pytest.mark.vespa
 def test_vespa_search_adaptor__works(test_vespa):
     request = SearchParameters(query_string="the")


### PR DESCRIPTION
# Description

There are instances where we want to instantiate the `VespaSearchParameters` object without certificates. This PR integrates this functionality. 

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [X] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
