### PR TITLE
do query encoding on vespa

### DIFF
--- a/src/cpr_sdk/models/search.py
+++ b/src/cpr_sdk/models/search.py
@@ -91,6 +91,12 @@ class SearchParameters(BaseModel):
     the search is performed.
     """
 
+    experimental_encode_on_vespa: bool = False
+    """
+    Backend change to encode the query string on the Vespa side rather than through
+    the SDK.
+    """
+
     all_results: bool = False
     """
     Return all results rather than searching or ranking

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,5 +1,5 @@
 _MAJOR = "1"
-_MINOR = "4"
+_MINOR = "5"
 _PATCH = "4"
 _SUFFIX = ""
 

--- a/src/cpr_sdk/vespa.py
+++ b/src/cpr_sdk/vespa.py
@@ -103,9 +103,15 @@ def build_vespa_request_body(
         vespa_request_body["ranking.profile"] = "hybrid_no_closeness"
     else:
         vespa_request_body["ranking.profile"] = "hybrid"
-        vespa_request_body[
-            "input.query(query_embedding)"
-        ] = "embed(msmarco-distilbert-dot-v5, @query_string)"
+        if parameters.experimental_encode_on_vespa:
+            vespa_request_body[
+                "input.query(query_embedding)"
+            ] = "embed(msmarco-distilbert-dot-v5, @query_string)"
+        else:
+            vespa_request_body["input.query(query_embedding)"] = embedder.embed(
+                parameters.query_string, normalize=False, show_progress_bar=False
+            )
+
     return vespa_request_body
 
 

--- a/src/cpr_sdk/vespa.py
+++ b/src/cpr_sdk/vespa.py
@@ -103,9 +103,9 @@ def build_vespa_request_body(
         vespa_request_body["ranking.profile"] = "hybrid_no_closeness"
     else:
         vespa_request_body["ranking.profile"] = "hybrid"
-        vespa_request_body["input.query(query_embedding)"] = embedder.embed(
-            parameters.query_string, normalize=False, show_progress_bar=False
-        )
+        vespa_request_body[
+            "input.query(query_embedding)"
+        ] = "embed(msmarco-distilbert-dot-v5, @query_string)"
     return vespa_request_body
 
 

--- a/tests/local_vespa/test_app/services.xml
+++ b/tests/local_vespa/test_app/services.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
 <services version="1.0" xmlns:deploy="vespa" xmlns:preprocess="properties">
+    <component id="msmarco-distilbert-dot-v5" type="hugging-face-embedder">
+        <transformer-model url="https://huggingface.co/onnx-models/msmarco-distilbert-dot-v5-onnx/resolve/main/model.onnx"/>
+        <tokenizer-model url="https://huggingface.co/onnx-models/msmarco-distilbert-dot-v5-onnx/resolve/main/tokenizer.json"/>
+    </component>
 
     <container id="default" version="1.0">
         <document-api/>

--- a/tests/local_vespa/test_app/services.xml
+++ b/tests/local_vespa/test_app/services.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
 <services version="1.0" xmlns:deploy="vespa" xmlns:preprocess="properties">
-    <component id="msmarco-distilbert-dot-v5" type="hugging-face-embedder">
-        <transformer-model url="https://huggingface.co/onnx-models/msmarco-distilbert-dot-v5-onnx/resolve/main/model.onnx"/>
-        <tokenizer-model url="https://huggingface.co/onnx-models/msmarco-distilbert-dot-v5-onnx/resolve/main/tokenizer.json"/>
-    </component>
 
     <container id="default" version="1.0">
+        <component id="msmarco-distilbert-dot-v5" type="hugging-face-embedder">
+            <transformer-model url="https://huggingface.co/onnx-models/msmarco-distilbert-dot-v5-onnx/resolve/main/model.onnx"/>
+            <tokenizer-model url="https://huggingface.co/onnx-models/msmarco-distilbert-dot-v5-onnx/resolve/main/tokenizer.json"/>
+            <transformer-token-type-ids/>
+            <transformer-output>token_embeddings</transformer-output>
+        </component>
         <document-api/>
         <search/>
         <nodes deploy:environment="dev" count="1">


### PR DESCRIPTION
# Description

Adds `experimental_encode_on_vespa` flag to `SearchParameters` which enables query encoding on Vespa, and a test to check that encoding in the SDK returns the same results as encoding in Vespa. Also adds a 

**Note that this is designed so that the backend/staging can gradually implement this feature**. It will also require a PR to Vespa infra ([as follows](https://github.com/climatepolicyradar/navigator-infra/pull/730)).

### Will this remove `torch` from the backend?

Not yet, as we're keeping the old feature in! But `sentence-transformers` is only used by the `Embedder` class which is only used for query encoding, so we should be able to remove `torch` from the SDK in a future PR.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [x] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
