### PR TITLE
Feature/update queries to contain concepts query

### DIFF
--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
 _MINOR = "7"
-_PATCH = "1"
+_PATCH = "2"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,12 @@
 import json
-from pathlib import Path
 import tempfile
+from pathlib import Path
 
-import pytest
 import boto3
+import pytest
 from moto import mock_aws
 
 from cpr_sdk.search_adaptors import VespaSearchAdapter
-
 
 VESPA_TEST_SEARCH_URL = "http://localhost:8080"
 

--- a/tests/local_vespa/test_app/schemas/document_passage.sd
+++ b/tests/local_vespa/test_app/schemas/document_passage.sd
@@ -44,6 +44,34 @@ schema document_passage {
                 }
             }
         }
+
+        struct concept {
+            field name          type string {}
+            field id            type string {}
+            field parent_ids    type array<string> {}
+            field parent_names  type array<string> {}
+            field start         type int {}
+            field end           type int {}
+            field model         type string {}
+            field timestamp     type string {}
+        }
+
+        field concepts type array<concept> {
+            indexing: summary
+
+            struct-field name {
+                indexing: attribute
+            }
+            struct-field id {
+                indexing: attribute
+            }
+            struct-field model {
+                indexing: attribute
+            }
+            struct-field timestamp {
+                indexing: attribute
+            }
+        }
     }
 
     import field family_document_ref.family_name as family_name {}
@@ -95,6 +123,7 @@ schema document_passage {
         summary text_block_type {}
         summary text_block_page {}
         summary text_block_coords {}
+        summary concepts {}
     }
 
     rank-profile exact inherits default {

--- a/tests/local_vespa/test_app/schemas/document_passage.sd
+++ b/tests/local_vespa/test_app/schemas/document_passage.sd
@@ -44,6 +44,42 @@ schema document_passage {
                 }
             }
         }
+
+        struct parent_concept {
+            field id type string {}
+            field name type string {}
+        }
+
+        struct concept {
+            field name                       type string {}
+            field id                         type string {}
+            field parent_concepts            type array<parent_concept> {}
+            field parent_concept_ids_flat    type string {}
+            field start                      type int {}
+            field end                        type int {}
+            field model                      type string {}
+            field timestamp                  type string {}
+        }
+
+        field concepts type array<concept> {
+            indexing: summary
+
+            struct-field name {
+                indexing: attribute
+            }
+            struct-field id {
+                indexing: attribute
+            }
+            struct-field parent_concept_ids_flat {
+                indexing: attribute
+            }
+            struct-field model {
+                indexing: attribute
+            }
+            struct-field timestamp {
+                indexing: attribute
+            }
+        }
     }
 
     import field family_document_ref.family_name as family_name {}
@@ -95,6 +131,7 @@ schema document_passage {
         summary text_block_type {}
         summary text_block_page {}
         summary text_block_coords {}
+        summary concepts {}
     }
 
     rank-profile exact inherits default {

--- a/tests/local_vespa/test_app/schemas/document_passage.sd
+++ b/tests/local_vespa/test_app/schemas/document_passage.sd
@@ -44,6 +44,25 @@ schema document_passage {
                 }
             }
         }
+
+        struct concept {
+            field name          type string {}
+            field id            type string {}
+            field parent_ids    type array<string> {}
+            field parent_names  type array<string> {}
+            field start         type int {}
+            field end           type int {}
+            field model         type string {}
+            field timestamp     type string {}
+        }
+
+        field concepts type array<concept> {
+            indexing: summary
+
+            struct-field name {
+                indexing: attribute
+            }
+        }
     }
 
     import field family_document_ref.family_name as family_name {}
@@ -95,6 +114,7 @@ schema document_passage {
         summary text_block_type {}
         summary text_block_page {}
         summary text_block_coords {}
+        summary concepts {}
     }
 
     rank-profile exact inherits default {

--- a/tests/test_vespa_queries.py
+++ b/tests/test_vespa_queries.py
@@ -1,6 +1,8 @@
+import pytest
 from vespa.io import VespaQueryResponse
 
 
+@pytest.mark.vespa
 def test_concepts(test_vespa) -> None:
     """Test that we can retrieve concepts from a document."""
     response: VespaQueryResponse = test_vespa.client.query(

--- a/tests/test_vespa_queries.py
+++ b/tests/test_vespa_queries.py
@@ -4,20 +4,21 @@ from vespa.io import VespaQueryResponse
 
 @pytest.mark.vespa
 @pytest.mark.parametrize(
-    "field,value",
+    "field,value,search_term",
     [
-        ("name", "sectors"),
-        ("id", "concept_137_137"),
-        ("model", "environment_model"),
-        ("timestamp", "2024-09-26T16:15:39.817896"),
+        ("name", "sectors", "contains"),
+        ("id", "concept_137_137", "contains"),
+        ("model", "environment_model", "contains"),
+        ("timestamp", "2024-09-26T16:15:39.817896", "contains"),
+        ("parent_concept_ids_flat", "Q1", "matches"),
     ],
 )
-def test_concepts(test_vespa, field, value) -> None:
+def test_concepts(test_vespa, field, search_term, value) -> None:
     """Test that we can retrieve concepts from a document."""
     response: VespaQueryResponse = test_vespa.client.query(
         yql="select * from document_passage "
         "where concepts contains "
-        f'sameElement({field} contains "{value}")'
+        f'sameElement({field} {search_term} "{value}")'
     )
 
     assert response.is_successful()

--- a/tests/test_vespa_queries.py
+++ b/tests/test_vespa_queries.py
@@ -3,24 +3,24 @@ from vespa.io import VespaQueryResponse
 
 
 @pytest.mark.vespa
-def test_concepts(test_vespa) -> None:
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("name", "sectors"),
+        ("id", "concept_137_137"),
+        ("model", "environment_model"),
+        ("timestamp", "2024-09-26T16:15:39.817896"),
+    ],
+)
+def test_concepts(test_vespa, field, value) -> None:
     """Test that we can retrieve concepts from a document."""
     response: VespaQueryResponse = test_vespa.client.query(
         yql="select * from document_passage "
         "where concepts contains "
-        'sameElement(name contains "sectors")'
+        f'sameElement({field} contains "{value}")'
     )
 
     assert response.is_successful()
     assert len(response.hits) > 0
     for hit in response.hits:
-        assert "sectors" in [concept["name"] for concept in hit["fields"]["concepts"]]
-
-    response: VespaQueryResponse = test_vespa.client.query(
-        yql="select * from document_passage "
-        "where concepts contains "
-        'sameElement(name contains "sectors", parent_ids contains "concept_0")'
-    )
-
-    assert response.is_successful()
-    assert len(response.hits) > 0
+        assert value in [concept[field] for concept in hit["fields"]["concepts"]]

--- a/tests/test_vespa_queries.py
+++ b/tests/test_vespa_queries.py
@@ -1,0 +1,24 @@
+from vespa.io import VespaQueryResponse
+
+
+def test_concepts(test_vespa) -> None:
+    """Test that we can retrieve concepts from a document."""
+    response: VespaQueryResponse = test_vespa.client.query(
+        yql="select * from document_passage "
+        "where concepts contains "
+        'sameElement(name contains "sectors")'
+    )
+
+    assert response.is_successful()
+    assert len(response.hits) > 0
+    for hit in response.hits:
+        assert "sectors" in [concept["name"] for concept in hit["fields"]["concepts"]]
+
+    response: VespaQueryResponse = test_vespa.client.query(
+        yql="select * from document_passage "
+        "where concepts contains "
+        'sameElement(name contains "sectors", parent_ids contains "concept_0")'
+    )
+
+    assert response.is_successful()
+    assert len(response.hits) > 0

--- a/tests/test_vespa_queries.py
+++ b/tests/test_vespa_queries.py
@@ -10,7 +10,7 @@ from vespa.io import VespaQueryResponse
         ("id", "concept_137_137", "contains"),
         ("model", "environment_model", "contains"),
         ("timestamp", "2024-09-26T16:15:39.817896", "contains"),
-        ("parent_concept_ids_flat", "Q1", "matches"),
+        ("parent_concept_ids_flat", "Q1,", "matches"),
     ],
 )
 def test_concepts(test_vespa, field, search_term, value) -> None:
@@ -24,4 +24,17 @@ def test_concepts(test_vespa, field, search_term, value) -> None:
     assert response.is_successful()
     assert len(response.hits) > 0
     for hit in response.hits:
-        assert value in [concept[field] for concept in hit["fields"]["concepts"]]
+        all_concepts_field_values = [concept[field] for concept in hit["fields"]["concepts"]]
+        if field == "parent_concept_ids_flat":
+            parent_concept_ids: list[list[str]] = [
+                parent_concept_ids_flat.split(",")
+                for parent_concept_ids_flat in all_concepts_field_values
+            ]
+            assert any(
+                [
+                    value.replace(",", "") in parent_concept_id
+                    for parent_concept_id in parent_concept_ids
+                ]
+            )
+        else:
+            assert value in all_concepts_field_values

--- a/tests/test_vespa_queries.py
+++ b/tests/test_vespa_queries.py
@@ -24,7 +24,9 @@ def test_concepts(test_vespa, field, search_term, value) -> None:
     assert response.is_successful()
     assert len(response.hits) > 0
     for hit in response.hits:
-        all_concepts_field_values = [concept[field] for concept in hit["fields"]["concepts"]]
+        all_concepts_field_values = [
+            concept[field] for concept in hit["fields"]["concepts"]
+        ]
         if field == "parent_concept_ids_flat":
             parent_concept_ids: list[list[str]] = [
                 parent_concept_ids_flat.split(",")


### PR DESCRIPTION
# Description

Adding some basic test queries not using the yql builder but simple yql syntax to assert that we can successfully retrieve data from vespa post schema updates. 

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [X] Patch
- [] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
