### PR TITLE
to_passage_level_json separates naming of text block fields

### DIFF
--- a/src/cpr_sdk/parser_models.py
+++ b/src/cpr_sdk/parser_models.py
@@ -434,7 +434,7 @@ class ParserOutput(BaseParserOutput):
                 {key: None for key in empty_html_text_block_keys}
                 | {key: None for key in empty_pdf_text_block_keys}
                 | fixed_fields_dict
-                | {"block_index": 0, PDF_PAGE_METADATA_KEY: None}
+                | {"text_block.index": 0, PDF_PAGE_METADATA_KEY: None}
             ]
 
             return passages_array_filled
@@ -444,7 +444,7 @@ class ParserOutput(BaseParserOutput):
             | self._rename_text_block_keys(
                 json.loads(block.model_dump_json(exclude={"text"}))
             )
-            | {"text_block.text": block.to_string(), "block_index": idx}
+            | {"text_block.text": block.to_string(), "text_block.index": idx}
             for idx, block in enumerate(self.text_blocks)
         ]
 

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
-_MINOR = "7"
-_PATCH = "1"
+_MINOR = "8"
+_PATCH = "0"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)

--- a/tests/test_parser_models.py
+++ b/tests/test_parser_models.py
@@ -180,7 +180,7 @@ def test_to_passage_level_json_method(
         + [f"text_block.{k}" for k in list(HTMLTextBlock.model_fields.keys())]
         + [f"text_block.{k}" for k in list(PDFTextBlock.model_fields.keys())]
         + list(ParserOutput.model_fields.keys())
-        + ["block_index", PDF_PAGE_METADATA_KEY]
+        + ["text_block.index", PDF_PAGE_METADATA_KEY]
     )
 
     expected_document_metadata_fields = set(BackendDocument.model_fields.keys())

--- a/tests/test_parser_models.py
+++ b/tests/test_parser_models.py
@@ -176,9 +176,9 @@ def test_to_passage_level_json_method(
     kwarg in the `to_passage_level_json` method
     """
     expected_top_level_fields = set(
-        list(TextBlock.model_fields.keys())
-        + list(HTMLTextBlock.model_fields.keys())
-        + list(PDFTextBlock.model_fields.keys())
+        [f"text_block.{k}" for k in list(TextBlock.model_fields.keys())]
+        + [f"text_block.{k}" for k in list(HTMLTextBlock.model_fields.keys())]
+        + [f"text_block.{k}" for k in list(PDFTextBlock.model_fields.keys())]
         + list(ParserOutput.model_fields.keys())
         + ["block_index", PDF_PAGE_METADATA_KEY]
     )


### PR DESCRIPTION
# Description

For easier use of the Huggingface open data, it's helpful if documents, families and text blocks have their own column 'namespace', e.g. so `document.languages` is not confused with `text_block.languages`.

This PR changes the function which creates the data format for the open data to introduce the `text_block.` prefix for all text block related fields.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [x] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
