### PR TITLE
Feature/add concept filters field validation

### DIFF
--- a/src/cpr_sdk/models/search.py
+++ b/src/cpr_sdk/models/search.py
@@ -245,6 +245,15 @@ class SearchParameters(BaseModel):
     A field and item mapping to search in the concepts field of the document passages.
     """
 
+    @field_validator("concept_filters", "documents_only")
+    def concept_filters_not_set_if_documents_only(cls, concept_filters, documents_only):
+        """Ensure concept_filters are not set if browse mode (documents_only) is set."""
+        if concept_filters and documents_only:
+            raise ValueError(
+                "Cannot set concept_filters when browse_mode is set. This is as concept_filters are only applicable to passages."
+            )
+        return concept_filters
+
     @model_validator(mode="after")
     def validate(self):
         """Validate against mutually exclusive fields"""

--- a/src/cpr_sdk/models/search.py
+++ b/src/cpr_sdk/models/search.py
@@ -261,7 +261,7 @@ class SearchParameters(BaseModel):
         """Ensure concept_filters are not set if browse mode (documents_only) is set."""
         if self.concept_filters is not None and self.documents_only is True:
             raise ValueError(
-                "Cannot set concept_filters when browse_mode is set. This is as concept_filters are only applicable to passages."
+                "Cannot set concept_filters when only searching documents. This is as concept_filters are only applicable to passages."
             )
         return self
 

--- a/src/cpr_sdk/models/search.py
+++ b/src/cpr_sdk/models/search.py
@@ -245,15 +245,6 @@ class SearchParameters(BaseModel):
     A field and item mapping to search in the concepts field of the document passages.
     """
 
-    @field_validator("concept_filters", "documents_only")
-    def concept_filters_not_set_if_documents_only(cls, concept_filters, documents_only):
-        """Ensure concept_filters are not set if browse mode (documents_only) is set."""
-        if concept_filters is not None and documents_only is True:
-            raise ValueError(
-                "Cannot set concept_filters when browse_mode is set. This is as concept_filters are only applicable to passages."
-            )
-        return concept_filters
-
     @model_validator(mode="after")
     def validate(self):
         """Validate against mutually exclusive fields"""
@@ -262,6 +253,15 @@ class SearchParameters(BaseModel):
         if self.documents_only and not self.all_results:
             raise ValueError(
                 "`documents_only` requires `all_results`, other queries are not supported"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def concept_filters_not_set_if_documents_only(self) -> "SearchParameters":
+        """Ensure concept_filters are not set if browse mode (documents_only) is set."""
+        if self.concept_filters is not None and self.documents_only is True:
+            raise ValueError(
+                "Cannot set concept_filters when browse_mode is set. This is as concept_filters are only applicable to passages."
             )
         return self
 

--- a/src/cpr_sdk/models/search.py
+++ b/src/cpr_sdk/models/search.py
@@ -248,7 +248,7 @@ class SearchParameters(BaseModel):
     @field_validator("concept_filters", "documents_only")
     def concept_filters_not_set_if_documents_only(cls, concept_filters, documents_only):
         """Ensure concept_filters are not set if browse mode (documents_only) is set."""
-        if concept_filters and documents_only:
+        if concept_filters is not None and documents_only is True:
             raise ValueError(
                 "Cannot set concept_filters when browse_mode is set. This is as concept_filters are only applicable to passages."
             )

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
 _MINOR = "9"
-_PATCH = "0"
+_PATCH = "1"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)

--- a/tests/test_search_adaptors.py
+++ b/tests/test_search_adaptors.py
@@ -501,6 +501,13 @@ def test_vespa_search_adaptor__corpus_type_name(
                 {"name": "id", "value": "concept_0_0"},
             ],
         ),
+        (
+            "",
+            [
+                {"name": "parent_concept_ids_flat", "value": "Q0,"},
+                {"name": "id", "value": "concept_0_0"},
+            ],
+        ),
     ],
 )
 def test_vespa_search_adaptor__concept_filter(
@@ -513,6 +520,7 @@ def test_vespa_search_adaptor__concept_filter(
             ConceptFilter.model_validate(concept_filter)
             for concept_filter in concept_filters
         ],
+        documents_only=False,
     )
     response = vespa_search(test_vespa, request)
     assert response.total_family_hits > 0

--- a/tests/test_search_parameters.py
+++ b/tests/test_search_parameters.py
@@ -19,7 +19,7 @@ from cpr_sdk.models.search import SearchParameters
                 "concept_filters": [{"name": "name", "value": "environment"}],
             },
             True,
-            "Cannot set concept_filters when browse_mode is set.",
+            "Cannot set concept_filters when only searching documents.",
         ),
         (
             {

--- a/tests/test_search_parameters.py
+++ b/tests/test_search_parameters.py
@@ -1,0 +1,42 @@
+from typing import Optional
+
+import pytest
+from pydantic_core import ValidationError
+
+from cpr_sdk.models.search import SearchParameters
+
+
+@pytest.mark.parametrize(
+    "params,expect_error,error_message",
+    [
+        (
+            {"query_string": "the", "exact_match": False, "all_results": True},
+            False,
+            None,
+        ),
+        ({"query_string": "", "exact_match": False, "all_results": True}, False, None),
+        (
+            {
+                "query_string": "",
+                "exact_match": False,
+                "all_results": True,
+                "concept_filters": [{"name": "name", "value": "environment"}],
+            },
+            True,
+            "Cannot set concept_filters when browse_mode is set.",
+        ),
+    ],
+)
+@pytest.mark.vespa
+def test_vespa_search_parameters(
+    params: dict, expect_error: bool, error_message: Optional[str]
+) -> None:
+    """Test that we can correctly instantiate the SearchParameters object."""
+    if expect_error:
+        with pytest.raises(
+            ValidationError,
+            match=error_message,
+        ):
+            SearchParameters.model_validate(params)
+    else:
+        SearchParameters.model_validate(params)

--- a/tests/test_search_parameters.py
+++ b/tests/test_search_parameters.py
@@ -9,21 +9,26 @@ from cpr_sdk.models.search import SearchParameters
 @pytest.mark.parametrize(
     "params,expect_error,error_message",
     [
-        (
-            {"query_string": "the", "exact_match": False, "all_results": True},
-            False,
-            None,
-        ),
-        ({"query_string": "", "exact_match": False, "all_results": True}, False, None),
+        ({"query_string": "the"}, False, None),
+        ({"query_string": ""}, False, None),
         (
             {
                 "query_string": "",
-                "exact_match": False,
+                "documents_only": True,
                 "all_results": True,
                 "concept_filters": [{"name": "name", "value": "environment"}],
             },
             True,
             "Cannot set concept_filters when browse_mode is set.",
+        ),
+        (
+            {
+                "query_string": "",
+                "documents_only": False,
+                "concept_filters": [{"name": "name", "value": "environment"}],
+            },
+            False,
+            None,
         ),
     ],
 )


### PR DESCRIPTION
# Description

This pull request implements a validation check of the search parameters pydantic object as well as related test updates to solve the following problem: 

If there is no query string and `documents_only=True` in the vespa search parameters this results in only the `family_document` index being searched in vespa. Concepts only exist on the `document_passage` index and thus we receive a query error. 

Therefore, we are implementing a check in the search parameters to make sure this doesn't happen. 


## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [X] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
