### PR TITLE
Feature/pods 1913 remove description embedding from yql

### DIFF
--- a/src/cpr_sdk/yql_builder.py
+++ b/src/cpr_sdk/yql_builder.py
@@ -69,18 +69,16 @@ class YQLBuilder:
             return """
                 (
                     (
-                    {"targetHits": 1000} weakAnd(
-                        family_name contains(@query_string),
-                        family_description contains(@query_string),
-                        text_block contains(@query_string)
-                    )
-                    ) or (
-                        [{"targetNumHits": 1000}]
-                        nearestNeighbor(family_description_embedding,query_embedding)
-                    ) or (
-                        [{"targetNumHits": 1000}]
-                        nearestNeighbor(text_embedding,query_embedding)
-                    )
+                        {"targetHits": 1000} weakAnd(
+                            family_name contains(@query_string),
+                            family_description contains(@query_string),
+                            text_block contains(@query_string)
+                        )
+                    ) 
+                    or (
+                            [{"targetNumHits": 1000}]
+                            nearestNeighbor(text_embedding,query_embedding)
+                        )
                 )
             """
 

--- a/src/cpr_sdk/yql_builder.py
+++ b/src/cpr_sdk/yql_builder.py
@@ -58,22 +58,14 @@ class YQLBuilder:
         elif self.sensitive:
             return """
                 (
-                    {"targetHits": 1000} weakAnd(
-                        family_name contains(@query_string),
-                        family_description contains(@query_string),
-                        text_block contains(@query_string)
-                    )
+                    userInput(@query_string)
                 )
             """
         else:
             return """
                 (
                     (
-                        {"targetHits": 1000} weakAnd(
-                            family_name contains(@query_string),
-                            family_description contains(@query_string),
-                            text_block contains(@query_string)
-                        )
+                        userInput(@query_string)
                     ) 
                     or (
                             [{"targetNumHits": 1000}]


### PR DESCRIPTION
# Description

Removes the `nearestNeighbor(family_description_embedding,query_embedding)` from the YQL query.

Also replaces `weakAnd` with `userInput`, as the logic of the former seems to sometimes act like an AND. This meant that in tests the document with no text blocks was not getting returned for any queries, as it always was false for the `text_block` clause.

[UserInput docs for reference](https://docs.vespa.ai/en/reference/query-language-reference.html#userinput). (This should also open us up to _"i want to search this exact phrase"_ queries, which is supported by UserInput, so we'd just need to disable the nearestneighbour YQL clause in this case)

## How Has This Been Tested?

Tests still pass as-is. Also tested on staging that results seem sensible using the CLI in the search-tests repo.