### PR TITLE
Bugfix/correct the validation method on the concept object

### DIFF
--- a/src/cpr_sdk/models/search.py
+++ b/src/cpr_sdk/models/search.py
@@ -95,21 +95,22 @@ class Concept(BaseModel):
         """
         Validate parent_concept_ids_flat field.
 
-        This field should hold the same concepts as the parent_concepts field.
+        This field should hold the same ids as concepts in the parent_concepts field.
         """
         parent_concept_ids_flattened = ",".join(
-            [parent_concept["name"] for parent_concept in self.parent_concepts]
+            [parent_concept["id"] for parent_concept in self.parent_concepts]
         )
 
-        if parent_concept_ids_flattened[-1] != ",":
-            parent_concept_ids_flattened += ","
-
-        if not self.parent_concept_ids_flat == parent_concept_ids_flattened:
+        if not (
+            self.parent_concept_ids_flat == parent_concept_ids_flattened
+            or self.parent_concept_ids_flat == parent_concept_ids_flattened + ","
+        ):
             raise ValueError(
                 "parent_concept_ids_flat must be a comma separated list of parent "
-                "concept names. "
-                f"Received parent_concept_ids_flat data: {self.parent_concept_ids_flat},"
-                f"received parent_concept names: {parent_concept_ids_flattened}"
+                "concept ids held in the parent concepts field. "
+                f"Received parent_concept_ids_flat: {self.parent_concept_ids_flat}\n"
+                "Received ids in the parent_concept objects: "
+                f"{parent_concept_ids_flattened}"
             )
         return self
 

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
 _MINOR = "9"
-_PATCH = "1"
+_PATCH = "2"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
 _MINOR = "9"
-_PATCH = "2"
+_PATCH = "3"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime
 from pathlib import Path
 from typing import Iterable
 
@@ -18,7 +19,7 @@ from cpr_sdk.models import (
     Span,
     TextBlock,
 )
-from cpr_sdk.models.search import MetadataFilter
+from cpr_sdk.models.search import Concept, MetadataFilter
 
 
 @pytest.fixture
@@ -604,3 +605,38 @@ def test_metadatafilters() -> None:
 
     with pytest.raises(ValidationError):
         MetadataFilter.model_validate({"value": "test"})
+
+
+def test_vespa_concept_instantiation() -> None:
+    """
+    Test that the Vespa concept can be instantiated correctly.
+
+    There is a relationship to enforce between the parent_concepts objects and the
+    parent_concept_ids_flat fields.
+    """
+    Concept(
+        name="test_concept_name_1",
+        id="test_concept_id_1.1",
+        parent_concepts=[
+            {"id": "test_parent_concept_id_1", "name": "test_parent_concept_name_1"}
+        ],
+        parent_concept_ids_flat="test_parent_concept_id_1",
+        start=1,
+        end=10,
+        model="test_model_1",
+        timestamp=datetime.now(),
+    )
+
+    with pytest.raises(ValidationError):
+        Concept(
+            name="test_concept_name_2",
+            id="test_concept_id_2.1",
+            parent_concepts=[
+                {"id": "test_parent_concept_id_2", "name": "test_parent_concept_name_2"}
+            ],
+            parent_concept_ids_flat="test_parent_concept_id_1",
+            start=1,
+            end=10,
+            model="test_model_2",
+            timestamp=datetime.now(),
+        )


### PR DESCRIPTION
# Description

This pull request is a bug fix for the validation method on the vespa `Concept` object. We want to validate that the `parent_concept_ids_flat` field holds the same ids as those on the `parent_concepts` objects field. 

We were comparing the `parent_concept_ids_flat` against the name key in the `parent_concepts` object. This PR therefore presents a bugfix and a test. 

Once this PR goes in the test data in the backend and indexer repos can also be updated. 

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [X] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [X] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [X] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [X] If this PR fixes a bug, I've added a test that will fail without my fix.
- [X] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
