### PR TITLE
DON'T MERGE swap weakAnd to userInput in YQL

### DIFF
--- a/src/cpr_sdk/yql_builder.py
+++ b/src/cpr_sdk/yql_builder.py
@@ -58,26 +58,16 @@ class YQLBuilder:
         elif self.sensitive:
             return """
                 (
-                    {"targetHits": 1000} weakAnd(
-                        family_name contains(@query_string),
-                        family_description contains(@query_string),
-                        text_block contains(@query_string)
-                    )
+                    userInput(@query_string)
                 )
             """
         else:
             return """
                 (
                     (
-                    {"targetHits": 1000} weakAnd(
-                        family_name contains(@query_string),
-                        family_description contains(@query_string),
-                        text_block contains(@query_string)
-                    )
-                    ) or (
-                        [{"targetNumHits": 1000}]
-                        nearestNeighbor(family_description_embedding,query_embedding)
-                    ) or (
+                        userInput(@query_string)
+                    ) 
+                    or (
                         [{"targetNumHits": 1000}]
                         nearestNeighbor(text_embedding,query_embedding)
                     )


### PR DESCRIPTION
# Description

This is a change to fix a seeming bug that wasn't detected until removing description embeddings from the YQL query and Vespa schema. Pushing this change first to check that it. works with the current schema, then i'll push changes to the schema and YQL to remove embedding search on descriptions.

The issue this aims to fix is that `weakAnd` seems to sometimes act like an `AND`, meaning that empty documents can be removed from search results even when they match on _title_ or _summary_ fields.

[UserInput docs for reference](https://docs.vespa.ai/en/reference/query-language-reference.html#userinput). This should also open us up to "i want to search this exact phrase" queries, which is supported by UserInput, so we'd just need to disable the nearestneighbour YQL clause in this case


## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

No changes to tests, but current changes still pass locally.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
