### PR TITLE
Fix: exact match should not stem

### DIFF
--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
 _MINOR = "9"
-_PATCH = "4"
+_PATCH = "5"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)

--- a/src/cpr_sdk/vespa.py
+++ b/src/cpr_sdk/vespa.py
@@ -95,7 +95,7 @@ def build_vespa_request_body(parameters: SearchParameters) -> dict[str, str]:
     if parameters.all_results:
         pass
     elif parameters.exact_match:
-        vespa_request_body["ranking.profile"] = "exact"
+        vespa_request_body["ranking.profile"] = "exact_not_stemmed"
     elif sensitive:
         vespa_request_body["ranking.profile"] = "hybrid_no_closeness"
     else:

--- a/src/cpr_sdk/yql_builder.py
+++ b/src/cpr_sdk/yql_builder.py
@@ -50,9 +50,9 @@ class YQLBuilder:
         if self.params.exact_match:
             return """
                 (
-                    (family_name contains({stem: false}@query_string)) or
-                    (family_description contains({stem: false}@query_string)) or
-                    (text_block contains ({stem: false}@query_string))
+                    (family_name_not_stemmed contains({stem: false}@query_string)) or
+                    (family_description_not_stemmed contains({stem: false}@query_string)) or
+                    (text_block_not_stemmed contains ({stem: false}@query_string))
                 )
             """
         elif self.sensitive:

--- a/tests/local_vespa/test_app/schemas/document_passage.sd
+++ b/tests/local_vespa/test_app/schemas/document_passage.sd
@@ -141,7 +141,7 @@ schema document_passage {
 
     rank-profile exact inherits default {
         function text_score() {
-            expression: attribute(passage_weight) * fieldMatch(text_block)
+            expression: attribute(passage_weight) * fieldMatch(text_block_not_stemmed)
         }
         first-phase {
             expression: text_score()

--- a/tests/local_vespa/test_app/schemas/document_passage.sd
+++ b/tests/local_vespa/test_app/schemas/document_passage.sd
@@ -1,5 +1,10 @@
 schema document_passage {
 
+    field text_block_not_stemmed type string {
+        indexing: input text_block | summary | index
+        stemming: none
+    }
+
     document document_passage {
 
         field search_weights_ref type reference<search_weights> {

--- a/tests/local_vespa/test_app/schemas/document_passage.sd
+++ b/tests/local_vespa/test_app/schemas/document_passage.sd
@@ -139,14 +139,55 @@ schema document_passage {
         summary concepts {}
     }
 
+    document-summary search_summary_with_tokens {
+        summary family_name {}
+        summary family_description {}
+        summary family_import_id {}
+        summary family_slug {}
+        summary family_category {}
+        summary family_publication_ts {}
+        summary family_geography {}
+        summary family_geographies {}
+        summary family_source {}
+        summary document_import_id {}
+        summary document_slug {}
+        summary document_languages {}
+        summary document_content_type {}
+        summary document_cdn_object {}
+        summary document_source_url {}
+        summary corpus_import_id {}
+        summary corpus_type_name {}
+        summary metadata {}
+        summary text_block {}
+        summary text_block_id {}
+        summary text_block_type {}
+        summary text_block_page {}
+        summary text_block_coords {}
+        summary concepts {}
+        summary text_block_tokens {
+            source: text_block
+            tokens
+        }
+    }
+
     rank-profile exact inherits default {
+        function text_score() {
+            expression: attribute(passage_weight) * fieldMatch(text_block)
+        }
+        first-phase {
+            expression: text_score()
+        }
+        match-features: text_score() fieldMatch(text_block)
+    }
+    
+    rank-profile exact_not_stemmed inherits default {
         function text_score() {
             expression: attribute(passage_weight) * fieldMatch(text_block_not_stemmed)
         }
         first-phase {
             expression: text_score()
         }
-        match-features: text_score()
+        match-features: text_score() fieldMatch(text_block)
     }
 
     rank-profile hybrid_no_closeness inherits default {
@@ -156,7 +197,7 @@ schema document_passage {
         first-phase {
             expression: text_score()
         }
-        match-features: text_score()
+        match-features: text_score() bm25(text_block)
     }
 
     rank-profile hybrid inherits default {
@@ -169,6 +210,20 @@ schema document_passage {
         first-phase {
             expression: text_score()
         }
-        match-features: text_score()
+        match-features: text_score() bm25(text_block) closeness(text_embedding)
+    }
+    
+    rank-profile hybrid_custom_weight inherits default {
+        inputs {
+            query(query_embedding) tensor<float>(x[768])
+            query(bm25_weight) double
+        }
+        function text_score() {
+            expression: attribute(passage_weight) * (query(bm25_weight) * bm25(text_block) + closeness(text_embedding))
+        }
+        first-phase {
+            expression: text_score()
+        }
+        match-features: text_score() bm25(text_block) closeness(text_embedding)
     }
 }

--- a/tests/local_vespa/test_app/schemas/family_document.sd
+++ b/tests/local_vespa/test_app/schemas/family_document.sd
@@ -170,10 +170,10 @@ schema family_document {
 
     rank-profile exact inherits default {
         function name_score() {
-            expression: attribute(name_weight) * fieldMatch(family_name_index)
+            expression: attribute(name_weight) * fieldMatch(family_name_not_stemmed)
         }
         function description_score() {
-            expression: attribute(description_weight) * fieldMatch(family_description_index)
+            expression: attribute(description_weight) * fieldMatch(family_description_not_stemmed)
         }
         first-phase {
             expression: name_score() + description_score()

--- a/tests/local_vespa/test_app/schemas/family_document.sd
+++ b/tests/local_vespa/test_app/schemas/family_document.sd
@@ -1,5 +1,15 @@
 schema family_document {
 
+    field family_name_not_stemmed type string {
+        indexing: input family_name_index | index
+        stemming: none
+    }
+
+    field family_description_not_stemmed type string {
+        indexing: input family_description_index | index
+        stemming: none
+    }
+
     document family_document {
 
         field search_weights_ref type reference<search_weights> {

--- a/tests/local_vespa/test_app/schemas/family_document.sd
+++ b/tests/local_vespa/test_app/schemas/family_document.sd
@@ -170,6 +170,19 @@ schema family_document {
 
     rank-profile exact inherits default {
         function name_score() {
+            expression: attribute(name_weight) * fieldMatch(family_name_index)
+        }
+        function description_score() {
+            expression: attribute(description_weight) * fieldMatch(family_description_index)
+        }
+        first-phase {
+            expression: name_score() + description_score()
+        }
+        match-features: name_score() description_score()
+    }
+    
+    rank-profile exact_not_stemmed inherits default {
+        function name_score() {
             expression: attribute(name_weight) * fieldMatch(family_name_not_stemmed)
         }
         function description_score() {
@@ -209,6 +222,40 @@ schema family_document {
         }
         match-features: name_score() description_score()
     }
+    
+    rank-profile hybrid_no_description_embedding inherits default {
+        inputs {
+            query(query_embedding) tensor<float>(x[768])
+        }
+        function name_score() {
+            expression: attribute(name_weight) * bm25(family_name_index)
+        }
+        function description_score() {
+            expression: attribute(description_weight) * bm25(family_description_index)
+        }
+        first-phase {
+            expression: name_score() + description_score()
+        }
+        match-features: name_score() description_score()
+    }
+
+    rank-profile hybrid_custom_weight inherits default {
+        inputs {
+            query(query_embedding) tensor<float>(x[768])
+            query(bm25_weight) double
+        }
+        function name_score() {
+            expression: attribute(name_weight) * bm25(family_name_index)
+        }
+        function description_score() {
+            expression: attribute(description_weight) * bm25(family_description_index)
+        }
+        first-phase {
+            expression: name_score() + description_score()
+        }
+        match-features: name_score() description_score()
+    }
+
 
     document-summary search_summary {
         summary family_name {}
@@ -232,5 +279,40 @@ schema family_document {
         summary corpus_type_name {}
         summary collection_title {}
         summary collection_summary {}
+    }
+
+    document-summary search_summary_with_tokens {
+        summary family_name {}
+        summary family_description {}
+        summary family_import_id {}
+        summary family_slug {}
+        summary family_category {}
+        summary family_publication_ts {}
+        summary family_geography {}
+        summary family_geographies {}
+        summary family_source {}
+        summary document_import_id {}
+        summary document_title {}
+        summary document_slug {}
+        summary document_languages {}
+        summary document_content_type {}
+        summary document_cdn_object {}
+        summary document_source_url {}
+        summary metadata {}
+        summary corpus_import_id {}
+        summary corpus_type_name {}
+        summary collection_title {}
+        summary collection_summary {}
+        summary family_name_index {}
+        summary family_name_index_tokens {
+            source: family_name_index
+            tokens
+        }
+        summary family_description_index {}
+        summary family_description_index_tokens {
+            source: family_description_index
+            tokens
+        }
+        from-disk
     }
 }

--- a/tests/test_search_adaptors.py
+++ b/tests/test_search_adaptors.py
@@ -65,6 +65,20 @@ def test_vespa_search_adaptor__works(test_vespa):
     assert total_passage_count == response.total_hits
 
 
+@pytest.mark.vespa
+def test_vespa_search_adaptor__exact_search(test_vespa):
+    """Test that exact search works"""
+
+    request = SearchParameters(query_string="biodiversity", exact_match=True)
+    response = vespa_search(test_vespa, request)
+
+    assert response.total_hits > 0
+    for family in response.families:
+        for hit in family.hits:
+            if isinstance(hit, Passage):
+                assert "biodiversity" in hit.text_block.lower()
+
+
 @pytest.mark.parametrize(
     "params",
     (

--- a/tests/test_search_requests.py
+++ b/tests/test_search_requests.py
@@ -22,7 +22,11 @@ from cpr_sdk.vespa import build_vespa_request_body
 )
 def test_build_vespa_request_body(query_type, params):
     body = build_vespa_request_body(parameters=params)
-    assert body["ranking.profile"] == query_type
+    assert (
+        body["ranking.profile"] == query_type
+        if query_type != "exact"
+        else "exact_not_stemmed"
+    )
     for key, value in body.items():
         assert (
             len(value) > 0


### PR DESCRIPTION
# Description

Exact match now doesn't perform stemming. 

Added a failing test for 'biodiversity' then fixed it.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
