### PR TITLE
fix yql builder as CLI

### DIFF
--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
 _MINOR = "9"
-_PATCH = "5"
+_PATCH = "6"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)

--- a/src/cpr_sdk/yql_builder.py
+++ b/src/cpr_sdk/yql_builder.py
@@ -1,6 +1,7 @@
 from string import Template
 from typing import Optional
 
+from rich import print as rprint
 from cpr_sdk.models.search import Filters, SearchParameters
 
 
@@ -231,7 +232,9 @@ if __name__ == "__main__":
         exact_match=False,
         limit=10,
         max_hits_per_family=10,
-        filters=Filters(**{"document_languages": "value", "family_source": "value"}),
+        filters=Filters(
+            **{"document_languages": ["value"], "family_source": ["value"]}
+        ),
         year_range=(2000, 2020),
         continuation_tokens=None,
     )
@@ -240,3 +243,5 @@ if __name__ == "__main__":
         params=params,
         sensitive=False,
     ).to_str()
+
+    rprint(yql_new)


### PR DESCRIPTION
# Description

The neat little debug feature of `YQLBuilder` had got out of sync with the pydantic `Filter` model. Also added rich printing. 

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
