### PR TITLE
show individual ranking features in search responses

### DIFF
--- a/tests/local_vespa/test_app/schemas/document_passage.sd
+++ b/tests/local_vespa/test_app/schemas/document_passage.sd
@@ -177,7 +177,7 @@ schema document_passage {
         first-phase {
             expression: text_score()
         }
-        match-features: text_score() fieldMatch(text_block)
+        summary-features: text_score() fieldMatch(text_block)
     }
     
     rank-profile exact_not_stemmed inherits default {
@@ -187,7 +187,7 @@ schema document_passage {
         first-phase {
             expression: text_score()
         }
-        match-features: text_score() fieldMatch(text_block)
+        summary-features: text_score() fieldMatch(text_block)
     }
 
     rank-profile hybrid_no_closeness inherits default {
@@ -197,7 +197,7 @@ schema document_passage {
         first-phase {
             expression: text_score()
         }
-        match-features: text_score() bm25(text_block)
+        summary-features: text_score() bm25(text_block)
     }
 
     rank-profile hybrid inherits default {
@@ -210,7 +210,7 @@ schema document_passage {
         first-phase {
             expression: text_score()
         }
-        match-features: text_score() bm25(text_block) closeness(text_embedding)
+        summary-features: text_score() bm25(text_block) closeness(text_embedding)
     }
     
     rank-profile hybrid_custom_weight inherits default {
@@ -224,6 +224,6 @@ schema document_passage {
         first-phase {
             expression: text_score()
         }
-        match-features: text_score() bm25(text_block) closeness(text_embedding)
+        summary-features: text_score() bm25(text_block) closeness(text_embedding)
     }
 }

--- a/tests/local_vespa/test_app/schemas/family_document.sd
+++ b/tests/local_vespa/test_app/schemas/family_document.sd
@@ -178,7 +178,7 @@ schema family_document {
         first-phase {
             expression: name_score() + description_score()
         }
-        match-features: name_score() description_score()
+        summary-features: name_score() description_score()
     }
     
     rank-profile exact_not_stemmed inherits default {
@@ -191,7 +191,7 @@ schema family_document {
         first-phase {
             expression: name_score() + description_score()
         }
-        match-features: name_score() description_score()
+        summary-features: name_score() description_score()
     }
 
     rank-profile hybrid_no_closeness inherits default {
@@ -204,7 +204,7 @@ schema family_document {
         first-phase {
             expression: name_score() + description_score()
         }
-        match-features: name_score() description_score()
+        summary-features: name_score() description_score()
     }
 
     rank-profile hybrid inherits default {
@@ -220,7 +220,7 @@ schema family_document {
         first-phase {
             expression: name_score() + description_score()
         }
-        match-features: name_score() description_score()
+        summary-features: name_score() description_score()
     }
     
     rank-profile hybrid_no_description_embedding inherits default {
@@ -236,7 +236,7 @@ schema family_document {
         first-phase {
             expression: name_score() + description_score()
         }
-        match-features: name_score() description_score()
+        summary-features: name_score() description_score()
     }
 
     rank-profile hybrid_custom_weight inherits default {
@@ -253,7 +253,7 @@ schema family_document {
         first-phase {
             expression: name_score() + description_score()
         }
-        match-features: name_score() description_score()
+        summary-features: name_score() description_score()
     }
 
 


### PR DESCRIPTION
# Description

Spike on changing match-features to summary-features in the test schemas. This seems to be the way to get features to appear in search results 🎉 

![image](https://github.com/user-attachments/assets/ab6516a1-4b60-48de-aed0-f6a12fa594ad)



## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
