### PR TITLE
Vespa schema changes for query control & general quality of life

### DIFF
--- a/src/cpr_sdk/models/search.py
+++ b/src/cpr_sdk/models/search.py
@@ -414,6 +414,21 @@ class Hit(BaseModel):
             raise ValueError(f"Unknown response type: {response_type}")
         return hit
 
+    def __eq__(self, other):
+        """
+        Check if two hits are equal.
+
+        Ignores relevance and rank_features as these are dependent on non-deterministic query routing.
+        """
+        if not isinstance(other, self.__class__):
+            return False
+
+        fields_to_compare = [
+            f for f in self.__dict__.keys() if f not in ("relevance", "rank_features")
+        ]
+
+        return all(getattr(self, f) == getattr(other, f) for f in fields_to_compare)
+
 
 class Document(Hit):
     """A document search result hit."""
@@ -523,6 +538,20 @@ class Family(BaseModel):
     prev_continuation_token: Optional[str] = None
     relevance: Optional[float] = None
 
+    def __eq__(self, other):
+        """
+        Check if two Families are equal.
+
+        Ignores relevance as it's dependent on non-deterministic query routing.
+        """
+
+        if not isinstance(other, self.__class__):
+            return False
+
+        fields_to_compare = [f for f in self.__dict__.keys() if f not in ("relevance")]
+
+        return all(getattr(self, f) == getattr(other, f) for f in fields_to_compare)
+
 
 class SearchResponse(BaseModel):
     """Relevant results, and search response metadata"""
@@ -535,3 +564,21 @@ class SearchResponse(BaseModel):
     continuation_token: Optional[str] = None
     this_continuation_token: Optional[str] = None
     prev_continuation_token: Optional[str] = None
+
+    def __eq__(self, other):
+        """
+        Check if two hits are equal.
+
+        Ignores query time fields as they are non-deterministic.
+        """
+
+        if not isinstance(other, self.__class__):
+            return False
+
+        fields_to_compare = [
+            f
+            for f in self.__dict__.keys()
+            if f not in ("query_time_ms", "total_time_ms")
+        ]
+
+        return all(getattr(self, f) == getattr(other, f) for f in fields_to_compare)

--- a/src/cpr_sdk/models/search.py
+++ b/src/cpr_sdk/models/search.py
@@ -1,6 +1,6 @@
 import re
 from datetime import datetime
-from typing import List, Literal, Optional, Sequence
+from typing import List, Literal, Optional, Sequence, Any
 
 from pydantic import (
     AliasChoices,
@@ -249,6 +249,12 @@ class SearchParameters(BaseModel):
     concept_filters: Optional[Sequence[ConceptFilter]] = None
     """
     A field and item mapping to search in the concepts field of the document passages.
+    """
+
+    custom_vespa_request_body: Optional[dict[str, Any]] = None
+    """
+    Extra fields to be added to the vespa request body. Overrides any existing fields,
+    so can also be used to override YQL or ranking profiles.
     """
 
     @model_validator(mode="after")

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,5 +1,5 @@
 _MAJOR = "1"
-_MINOR = "11"
+_MINOR = "12"
 _PATCH = "0"
 _SUFFIX = ""
 

--- a/src/cpr_sdk/vespa.py
+++ b/src/cpr_sdk/vespa.py
@@ -104,6 +104,17 @@ def build_vespa_request_body(parameters: SearchParameters) -> dict[str, str]:
             "input.query(query_embedding)"
         ] = "embed(msmarco-distilbert-dot-v5, @query_string)"
 
+    if parameters.custom_vespa_request_body is not None:
+        overlapping_keys = set(vespa_request_body.keys()) & set(
+            parameters.custom_vespa_request_body.keys()
+        )
+        if overlapping_keys:
+            _LOGGER.warning(
+                f"Custom request body contains overlapping keys that will override defaults: {overlapping_keys}"
+            )
+
+        vespa_request_body = vespa_request_body | parameters.custom_vespa_request_body
+
     return vespa_request_body
 
 

--- a/tests/local_vespa/test_app/schemas/document_passage.sd
+++ b/tests/local_vespa/test_app/schemas/document_passage.sd
@@ -197,27 +197,19 @@ schema document_passage {
     rank-profile hybrid inherits default {
         inputs {
             query(query_embedding) tensor<float>(x[768])
+            query(passage_bm25_weight) double: 1.0
+            query(passage_closeness_weight) double: 1.0
         }
         function text_score() {
-            expression: attribute(passage_weight) * (bm25(text_block) + closeness(text_embedding))
+            expression: attribute(passage_weight) * (query(passage_bm25_weight) * bm25(text_block) + query(passage_closeness_weight) * closeness(text_embedding))
         }
         first-phase {
             expression: text_score()
         }
         summary-features: text_score() bm25(text_block) closeness(text_embedding)
+    }
+
+    rank-profile hybrid_no_embedding inherits hybrid {
     }
     
-    rank-profile hybrid_custom_weight inherits default {
-        inputs {
-            query(query_embedding) tensor<float>(x[768])
-            query(bm25_weight) double
-        }
-        function text_score() {
-            expression: attribute(passage_weight) * (query(bm25_weight) * bm25(text_block) + closeness(text_embedding))
-        }
-        first-phase {
-            expression: text_score()
-        }
-        summary-features: text_score() bm25(text_block) closeness(text_embedding)
-    }
 }

--- a/tests/local_vespa/test_app/schemas/document_passage.sd
+++ b/tests/local_vespa/test_app/schemas/document_passage.sd
@@ -5,6 +5,10 @@ schema document_passage {
         stemming: none
     }
 
+    field language type string {
+        indexing: "en" | set_language
+    }
+
     document document_passage {
 
         field search_weights_ref type reference<search_weights> {

--- a/tests/local_vespa/test_app/schemas/document_passage.sd
+++ b/tests/local_vespa/test_app/schemas/document_passage.sd
@@ -143,31 +143,7 @@ schema document_passage {
         summary concepts {}
     }
 
-    document-summary search_summary_with_tokens {
-        summary family_name {}
-        summary family_description {}
-        summary family_import_id {}
-        summary family_slug {}
-        summary family_category {}
-        summary family_publication_ts {}
-        summary family_geography {}
-        summary family_geographies {}
-        summary family_source {}
-        summary document_import_id {}
-        summary document_slug {}
-        summary document_languages {}
-        summary document_content_type {}
-        summary document_cdn_object {}
-        summary document_source_url {}
-        summary corpus_import_id {}
-        summary corpus_type_name {}
-        summary metadata {}
-        summary text_block {}
-        summary text_block_id {}
-        summary text_block_type {}
-        summary text_block_page {}
-        summary text_block_coords {}
-        summary concepts {}
+    document-summary search_summary_with_tokens inherits search_summary {
         summary text_block_tokens {
             source: text_block
             tokens

--- a/tests/local_vespa/test_app/schemas/document_passage.sd
+++ b/tests/local_vespa/test_app/schemas/document_passage.sd
@@ -9,11 +9,6 @@ schema document_passage {
         stemming: none
     }
 
-    field text_block_bolding type string {
-        indexing: input text_block | summary | index
-        bolding: true
-    }
-
     document document_passage {
 
         field search_weights_ref type reference<search_weights> {

--- a/tests/local_vespa/test_app/schemas/document_passage.sd
+++ b/tests/local_vespa/test_app/schemas/document_passage.sd
@@ -204,8 +204,5 @@ schema document_passage {
             query(passage_closeness_weight) double: 0.0
         }
     }
-
-    rank-profile hybrid_no_description_embedding inherits hybrid {
-    }
     
 }

--- a/tests/local_vespa/test_app/schemas/document_passage.sd
+++ b/tests/local_vespa/test_app/schemas/document_passage.sd
@@ -9,6 +9,11 @@ schema document_passage {
         indexing: "en" | set_language
     }
 
+    field text_block_bolding type string {
+        indexing: input text_block | summary | index
+        bolding: true
+    }
+
     document document_passage {
 
         field search_weights_ref type reference<search_weights> {

--- a/tests/local_vespa/test_app/schemas/document_passage.sd
+++ b/tests/local_vespa/test_app/schemas/document_passage.sd
@@ -174,6 +174,21 @@ schema document_passage {
         }
         summary-features: text_score() bm25(text_block) closeness(text_embedding) attribute(passage_weight)
     }
+    
+    rank-profile hybrid_nativerank inherits default {
+        inputs {
+            query(query_embedding) tensor<float>(x[768])
+            query(passage_nativerank_weight) double: 1.0
+            query(passage_closeness_weight) double: 1.0
+        }
+        function text_score() {
+            expression: query(passage_nativerank_weight) * nativeRank(text_block) + query(passage_closeness_weight) * closeness(text_embedding)
+        }
+        first-phase {
+            expression: attribute(passage_weight) * text_score()
+        }
+        summary-features: text_score() nativeRank(text_block) closeness(text_embedding) attribute(passage_weight)
+    }
 
     rank-profile hybrid_no_closeness inherits hybrid {
         inputs {

--- a/tests/local_vespa/test_app/schemas/document_passage.sd
+++ b/tests/local_vespa/test_app/schemas/document_passage.sd
@@ -173,16 +173,6 @@ schema document_passage {
             tokens
         }
     }
-
-    rank-profile exact inherits default {
-        function text_score() {
-            expression: attribute(passage_weight) * fieldMatch(text_block)
-        }
-        first-phase {
-            expression: text_score()
-        }
-        summary-features: text_score() fieldMatch(text_block)
-    }
     
     rank-profile exact_not_stemmed inherits default {
         function text_score() {

--- a/tests/local_vespa/test_app/schemas/document_passage.sd
+++ b/tests/local_vespa/test_app/schemas/document_passage.sd
@@ -184,16 +184,6 @@ schema document_passage {
         summary-features: text_score() fieldMatch(text_block)
     }
 
-    rank-profile hybrid_no_closeness inherits default {
-        function text_score() {
-            expression: attribute(passage_weight) * bm25(text_block)
-        }
-        first-phase {
-            expression: text_score()
-        }
-        summary-features: text_score() bm25(text_block)
-    }
-
     rank-profile hybrid inherits default {
         inputs {
             query(query_embedding) tensor<float>(x[768])
@@ -209,7 +199,13 @@ schema document_passage {
         summary-features: text_score() bm25(text_block) closeness(text_embedding)
     }
 
-    rank-profile hybrid_no_embedding inherits hybrid {
+    rank-profile hybrid_no_closeness inherits hybrid {
+        inputs {
+            query(passage_closeness_weight) double: 0.0
+        }
+    }
+
+    rank-profile hybrid_no_description_embedding inherits hybrid {
     }
     
 }

--- a/tests/local_vespa/test_app/schemas/document_passage.sd
+++ b/tests/local_vespa/test_app/schemas/document_passage.sd
@@ -1,12 +1,12 @@
 schema document_passage {
 
+    field language type string {
+        indexing: "en" | set_language
+    }
+
     field text_block_not_stemmed type string {
         indexing: input text_block | summary | index
         stemming: none
-    }
-
-    field language type string {
-        indexing: "en" | set_language
     }
 
     field text_block_bolding type string {

--- a/tests/local_vespa/test_app/schemas/document_passage.sd
+++ b/tests/local_vespa/test_app/schemas/document_passage.sd
@@ -152,12 +152,12 @@ schema document_passage {
     
     rank-profile exact_not_stemmed inherits default {
         function text_score() {
-            expression: attribute(passage_weight) * fieldMatch(text_block_not_stemmed)
+            expression: fieldMatch(text_block_not_stemmed)
         }
         first-phase {
-            expression: text_score()
+            expression: attribute(passage_weight) * text_score()
         }
-        summary-features: text_score() fieldMatch(text_block)
+        summary-features: attribute(passage_weight) text_score()
     }
 
     rank-profile hybrid inherits default {
@@ -167,12 +167,12 @@ schema document_passage {
             query(passage_closeness_weight) double: 1.0
         }
         function text_score() {
-            expression: attribute(passage_weight) * (query(passage_bm25_weight) * bm25(text_block) + query(passage_closeness_weight) * closeness(text_embedding))
+            expression: query(passage_bm25_weight) * bm25(text_block) + query(passage_closeness_weight) * closeness(text_embedding)
         }
         first-phase {
-            expression: text_score()
+            expression: attribute(passage_weight) * text_score()
         }
-        summary-features: text_score() bm25(text_block) closeness(text_embedding)
+        summary-features: text_score() bm25(text_block) closeness(text_embedding) attribute(passage_weight)
     }
 
     rank-profile hybrid_no_closeness inherits hybrid {

--- a/tests/local_vespa/test_app/schemas/family_document.sd
+++ b/tests/local_vespa/test_app/schemas/family_document.sd
@@ -195,7 +195,7 @@ schema family_document {
             expression: bm25(family_name_index)
         }
         function description_score() {
-            expression: query(description_bm25_weight) * bm25(family_description_index) + query(descriptione_closeness_weight) * closeness(family_description_embedding)
+            expression: query(description_bm25_weight) * bm25(family_description_index) + query(description_closeness_weight) * closeness(family_description_embedding)
         }
         first-phase {
             expression: (attribute(name_weight) * name_score()) + (attribute(description_weight) * description_score())

--- a/tests/local_vespa/test_app/schemas/family_document.sd
+++ b/tests/local_vespa/test_app/schemas/family_document.sd
@@ -223,7 +223,7 @@ schema family_document {
             expression: nativeRank(family_name_index)
         }
         function description_score() {
-            expression: query(description_nativerank_weight) * nativeRank(family_description_index) + query(descriptione_closeness_weight) * closeness(family_description_embedding)
+            expression: query(description_nativerank_weight) * nativeRank(family_description_index) + query(description_closeness_weight) * closeness(family_description_embedding)
         }
         first-phase {
             expression: (attribute(name_weight) * name_score()) + (attribute(description_weight) * description_score())

--- a/tests/local_vespa/test_app/schemas/family_document.sd
+++ b/tests/local_vespa/test_app/schemas/family_document.sd
@@ -202,6 +202,24 @@ schema family_document {
         }
         summary-features: name_score() description_score() bm25(family_name_index) bm25(family_description_index) closeness(family_description_embedding)
     }
+    
+    rank-profile hybrid_nativerank inherits default {
+        inputs {
+            query(query_embedding) tensor<float>(x[768])
+            query(description_nativerank_weight) double: 1.0
+            query(description_closeness_weight) double: 1.0
+        }
+        function name_score() {
+            expression: nativeRank(family_name_index)
+        }
+        function description_score() {
+            expression: query(description_nativerank_weight) * nativeRank(family_description_index) + query(descriptione_closeness_weight) * closeness(family_description_embedding)
+        }
+        first-phase {
+            expression: (attribute(name_weight) * name_score()) + (attribute(description_weight) * description_score())
+        }
+        summary-features: name_score() description_score() nativeRank(family_name_index) nativeRank(family_description_index) closeness(family_description_embedding)
+    }
 
     rank-profile hybrid_no_closeness inherits hybrid {
         inputs {

--- a/tests/local_vespa/test_app/schemas/family_document.sd
+++ b/tests/local_vespa/test_app/schemas/family_document.sd
@@ -172,19 +172,6 @@ schema family_document {
         fields: family_name_index, family_description_index
     }
 
-    rank-profile exact inherits default {
-        function name_score() {
-            expression: attribute(name_weight) * fieldMatch(family_name_index)
-        }
-        function description_score() {
-            expression: attribute(description_weight) * fieldMatch(family_description_index)
-        }
-        first-phase {
-            expression: name_score() + description_score()
-        }
-        summary-features: name_score() description_score()
-    }
-    
     rank-profile exact_not_stemmed inherits default {
         function name_score() {
             expression: attribute(name_weight) * fieldMatch(family_name_not_stemmed)

--- a/tests/local_vespa/test_app/schemas/family_document.sd
+++ b/tests/local_vespa/test_app/schemas/family_document.sd
@@ -1,5 +1,9 @@
 schema family_document {
 
+    field language type string {
+        indexing: "en" | set_language
+    }
+
     field family_name_not_stemmed type string {
         indexing: input family_name_index | index
         stemming: none
@@ -18,10 +22,6 @@ schema family_document {
     field family_description_bolding type string {
         indexing: input family_description_index | summary | index
         bolding: true
-    }
-
-    field language type string {
-        indexing: "en" | set_language
     }
 
     document family_document {

--- a/tests/local_vespa/test_app/schemas/family_document.sd
+++ b/tests/local_vespa/test_app/schemas/family_document.sd
@@ -10,6 +10,16 @@ schema family_document {
         stemming: none
     }
 
+    field family_name_bolding type string {
+        indexing: input family_name_index | index
+        bolding: true
+    }
+
+    field family_description_bolding type string {
+        indexing: input family_description_index | index
+        bolding: true
+    }
+
     field language type string {
         indexing: "en" | set_language
     }

--- a/tests/local_vespa/test_app/schemas/family_document.sd
+++ b/tests/local_vespa/test_app/schemas/family_document.sd
@@ -174,15 +174,15 @@ schema family_document {
 
     rank-profile exact_not_stemmed inherits default {
         function name_score() {
-            expression: attribute(name_weight) * fieldMatch(family_name_not_stemmed)
+            expression: fieldMatch(family_name_not_stemmed)
         }
         function description_score() {
-            expression: attribute(description_weight) * fieldMatch(family_description_not_stemmed)
+            expression: fieldMatch(family_description_not_stemmed)
         }
         first-phase {
-            expression: name_score() + description_score()
+            expression: attribute(name_weight) * name_score() + attribute(description_weight) * description_score()
         }
-        summary-features: name_score() description_score()
+        summary-features: name_score() description_score() attribute(name_weight) attribute(description_weight)
     }
 
     rank-profile hybrid inherits default {
@@ -200,7 +200,7 @@ schema family_document {
         first-phase {
             expression: (attribute(name_weight) * name_score()) + (attribute(description_weight) * description_score())
         }
-        summary-features: name_score() description_score()
+        summary-features: name_score() description_score() bm25(family_name_index) bm25(family_description_index) closeness(family_description_embedding)
     }
 
     rank-profile hybrid_no_closeness inherits hybrid {

--- a/tests/local_vespa/test_app/schemas/family_document.sd
+++ b/tests/local_vespa/test_app/schemas/family_document.sd
@@ -209,12 +209,6 @@ schema family_document {
         }
     }
     
-    rank-profile hybrid_no_description_embedding inherits hybrid {
-        inputs {
-            query(description_closeness_weight) double: 0.0
-        }
-    }
-
     document-summary search_summary {
         summary family_name {}
         summary family_description {}

--- a/tests/local_vespa/test_app/schemas/family_document.sd
+++ b/tests/local_vespa/test_app/schemas/family_document.sd
@@ -201,52 +201,26 @@ schema family_document {
     rank-profile hybrid inherits default {
         inputs {
             query(query_embedding) tensor<float>(x[768])
+            query(description_bm25_weight) double: 1.0
+            query(description_closeness_weight) double: 1.0
         }
         function name_score() {
-            expression: attribute(name_weight) * bm25(family_name_index)
+            expression: bm25(family_name_index)
         }
         function description_score() {
-            expression: attribute(description_weight) * (bm25(family_description_index) + closeness(family_description_embedding))
+            expression: query(description_bm25_weight) * bm25(family_description_index) + query(descriptione_closeness_weight) * closeness(family_description_embedding)
         }
         first-phase {
-            expression: name_score() + description_score()
+            expression: (attribute(name_weight) * name_score()) + (attribute(description_weight) * description_score())
         }
         summary-features: name_score() description_score()
     }
     
-    rank-profile hybrid_no_description_embedding inherits default {
+    rank-profile hybrid_no_description_embedding inherits hybrid {
         inputs {
-            query(query_embedding) tensor<float>(x[768])
+            query(description_closeness_weight) double: 0.0
         }
-        function name_score() {
-            expression: attribute(name_weight) * bm25(family_name_index)
-        }
-        function description_score() {
-            expression: attribute(description_weight) * bm25(family_description_index)
-        }
-        first-phase {
-            expression: name_score() + description_score()
-        }
-        summary-features: name_score() description_score()
     }
-
-    rank-profile hybrid_custom_weight inherits default {
-        inputs {
-            query(query_embedding) tensor<float>(x[768])
-            query(bm25_weight) double
-        }
-        function name_score() {
-            expression: attribute(name_weight) * bm25(family_name_index)
-        }
-        function description_score() {
-            expression: attribute(description_weight) * bm25(family_description_index)
-        }
-        first-phase {
-            expression: name_score() + description_score()
-        }
-        summary-features: name_score() description_score()
-    }
-
 
     document-summary search_summary {
         summary family_name {}

--- a/tests/local_vespa/test_app/schemas/family_document.sd
+++ b/tests/local_vespa/test_app/schemas/family_document.sd
@@ -11,12 +11,12 @@ schema family_document {
     }
 
     field family_name_bolding type string {
-        indexing: input family_name_index | index
+        indexing: input family_name_index | summary | index
         bolding: true
     }
 
     field family_description_bolding type string {
-        indexing: input family_description_index | index
+        indexing: input family_description_index | summary | index
         bolding: true
     }
 

--- a/tests/local_vespa/test_app/schemas/family_document.sd
+++ b/tests/local_vespa/test_app/schemas/family_document.sd
@@ -233,28 +233,7 @@ schema family_document {
         summary collection_summary {}
     }
 
-    document-summary search_summary_with_tokens {
-        summary family_name {}
-        summary family_description {}
-        summary family_import_id {}
-        summary family_slug {}
-        summary family_category {}
-        summary family_publication_ts {}
-        summary family_geography {}
-        summary family_geographies {}
-        summary family_source {}
-        summary document_import_id {}
-        summary document_title {}
-        summary document_slug {}
-        summary document_languages {}
-        summary document_content_type {}
-        summary document_cdn_object {}
-        summary document_source_url {}
-        summary metadata {}
-        summary corpus_import_id {}
-        summary corpus_type_name {}
-        summary collection_title {}
-        summary collection_summary {}
+    document-summary search_summary_with_tokens inherits search_summary {
         summary family_name_index {}
         summary family_name_index_tokens {
             source: family_name_index

--- a/tests/local_vespa/test_app/schemas/family_document.sd
+++ b/tests/local_vespa/test_app/schemas/family_document.sd
@@ -10,6 +10,10 @@ schema family_document {
         stemming: none
     }
 
+    field language type string {
+        indexing: "en" | set_language
+    }
+
     document family_document {
 
         field search_weights_ref type reference<search_weights> {

--- a/tests/local_vespa/test_app/schemas/family_document.sd
+++ b/tests/local_vespa/test_app/schemas/family_document.sd
@@ -14,16 +14,6 @@ schema family_document {
         stemming: none
     }
 
-    field family_name_bolding type string {
-        indexing: input family_name_index | summary | index
-        bolding: true
-    }
-
-    field family_description_bolding type string {
-        indexing: input family_description_index | summary | index
-        bolding: true
-    }
-
     document family_document {
 
         field search_weights_ref type reference<search_weights> {

--- a/tests/local_vespa/test_app/schemas/family_document.sd
+++ b/tests/local_vespa/test_app/schemas/family_document.sd
@@ -185,19 +185,6 @@ schema family_document {
         summary-features: name_score() description_score()
     }
 
-    rank-profile hybrid_no_closeness inherits default {
-        function name_score() {
-            expression: attribute(name_weight) * bm25(family_name_index)
-        }
-        function description_score() {
-            expression: attribute(description_weight) * bm25(family_description_index)
-        }
-        first-phase {
-            expression: name_score() + description_score()
-        }
-        summary-features: name_score() description_score()
-    }
-
     rank-profile hybrid inherits default {
         inputs {
             query(query_embedding) tensor<float>(x[768])
@@ -214,6 +201,12 @@ schema family_document {
             expression: (attribute(name_weight) * name_score()) + (attribute(description_weight) * description_score())
         }
         summary-features: name_score() description_score()
+    }
+
+    rank-profile hybrid_no_closeness inherits hybrid {
+        inputs {
+            query(description_closeness_weight) double: 0.0
+        }
     }
     
     rank-profile hybrid_no_description_embedding inherits hybrid {

--- a/tests/test_search_adaptors.py
+++ b/tests/test_search_adaptors.py
@@ -750,3 +750,27 @@ def test_vespa_search_response__geographies(
             hit = Hit.from_vespa_response(response_hit=hit)
             assert hit.family_geography not in [None, []]
             assert hit.family_geographies not in [None, []]
+
+
+@pytest.mark.vespa
+def test_vespa_search_hybrid_no_closeness_profile(test_vespa):
+    query_string = "the"
+
+    request_no_closeness = SearchParameters(
+        query_string=query_string,
+        custom_vespa_request_body={"ranking.profile": "hybrid_no_closeness"},
+    )
+    response_no_closeness = vespa_search(test_vespa, request_no_closeness)
+
+    request_null_closeness_weights = SearchParameters(
+        query_string=query_string,
+        custom_vespa_request_body={
+            "input.query(description_closeness_weight)": 0,
+            "input.query(passage_closeness_weight)": 0,
+        },
+    )
+    response_null_closeness_weights = vespa_search(
+        test_vespa, request_null_closeness_weights
+    )
+
+    assert response_no_closeness == response_null_closeness_weights


### PR DESCRIPTION
# Description

A batch of changes to the schema making use of inheritance, input parameters and summaries. These aim to mean we can have more control over search without requiring schema changes in future. **Recommended that the easiest way to go through this PR is by commit.**

**Change since reviews of the draft PR**: you can now add a custom request body in `SearchParameters`, which gives us full control over the `SearchAdaptor` without having to push field changes through the schema and then pydantic models, and more immediately gives us control over the weightings of individual query components. I've demonstrated this in a test which shows that setting the `closeness` features to 0 is the same as using the `hybrid_no_closeness` rank profile.

Also:
- set document languages to english
- ~adds text fields with `_bolding` suffixes which give the bolded version of each when a search is done~ _this didn't work, so have deleted it from this PR_
- adds a new hybrid profile with [nativeRank](https://docs.vespa.ai/en/nativerank.html) - Vespa's alternative to BM25 that gives you a little bit more control and produces normalised scores

**Sidenote: I tried to test this on the backend using the test pypi published package from this PR's CI but the Vespa dependency seemed to be broken on that.** Not sure whether this is just me or it's actually broken 🤷

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [x] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
