### PR TITLE
remove embedding search on descriptions

### DIFF
--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
 _MINOR = "12"
-_PATCH = "0"
+_PATCH = "1"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)

--- a/src/cpr_sdk/vespa.py
+++ b/src/cpr_sdk/vespa.py
@@ -115,6 +115,8 @@ def build_vespa_request_body(parameters: SearchParameters) -> dict[str, str]:
 
         vespa_request_body = vespa_request_body | parameters.custom_vespa_request_body
 
+    vespa_request_body["input.query(description_closeness_weight)"] = 0
+
     return vespa_request_body
 
 

--- a/src/cpr_sdk/vespa.py
+++ b/src/cpr_sdk/vespa.py
@@ -115,6 +115,7 @@ def build_vespa_request_body(parameters: SearchParameters) -> dict[str, str]:
 
         vespa_request_body = vespa_request_body | parameters.custom_vespa_request_body
 
+    # Disabling embedding search for descriptions
     vespa_request_body["input.query(description_closeness_weight)"] = 0
 
     return vespa_request_body

--- a/src/cpr_sdk/yql_builder.py
+++ b/src/cpr_sdk/yql_builder.py
@@ -68,9 +68,6 @@ class YQLBuilder:
                     (userInput(@query_string)) 
                     or (
                         [{"targetNumHits": 1000}]
-                        nearestNeighbor(family_description_embedding,query_embedding)
-                    ) or (
-                        [{"targetNumHits": 1000}]
                         nearestNeighbor(text_embedding,query_embedding)
                     )
                 )

--- a/tests/test_search_requests.py
+++ b/tests/test_search_requests.py
@@ -29,7 +29,7 @@ def test_build_vespa_request_body(query_type, params):
     )
     for key, value in body.items():
         assert (
-            len(value) > 0
+            not isinstance(value, str) or len(value) > 0
         ), f"Query type: {query_type} has an empty value for {key}: {value}"
 
 


### PR DESCRIPTION
# Description

For [the reasons described here](https://www.notion.so/climatepolicyradar/Decision-remove-semantic-search-from-family-summary-10d9109609a4800ebbe5c560efba78a1) – the main one of these being that it prevents a family with no matching text blocks for appearing in search results, with no words in common with their query. This will also let the UX for highlighting search terms in descriptions be easier if we ever get there.

Also, a nice example of the new control over Vespa via the SDK from the last set of changes!

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
