### PR TITLE
Test on latest vespa version

### DIFF
--- a/tests/local_vespa/docker-compose.dev.yml
+++ b/tests/local_vespa/docker-compose.dev.yml
@@ -1,6 +1,6 @@
 services:
   vespadaltest:
-    image: vespaengine/vespa:8.396.18
+    image: vespaengine/vespa:latest
     container_name: vespadaltest
     ports:
       - 8080:8080


### PR DESCRIPTION
# Description

Recently work on search fixes was stalled when trying to use a feature from a latter version then we were testing on. We run vespa tests in four repos and are currently updating the version manually across these.

Rather than pinning a version for our tests, if we instead always test on the latest we will also have more accurate coverage for what we deploy into vespa cloud, as the versions there are bumped automatically.

Pinning latest is obviously bad practice for production environments because it gives less control over what is live, however we are just using this image for our tests, where the concern doesnt apply.

- See motivation [on this pr](https://github.com/climatepolicyradar/cpr-sdk/pull/171#discussion_r1907188454).
- Once this is reviewed I'll also open this for the other repos this applies to

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [x] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
