### PR TITLE
Move concept fields to child objects

### DIFF
--- a/src/cpr_sdk/models/search.py
+++ b/src/cpr_sdk/models/search.py
@@ -437,10 +437,8 @@ class Hit(BaseModel):
     corpus_type_name: Optional[str] = None
     corpus_import_id: Optional[str] = None
     metadata: Optional[Sequence[dict[str, str]]] = None
-    concepts: Optional[Sequence[Concept]] = None
     relevance: Optional[float] = None
     rank_features: Optional[dict[str, float]] = None
-    concept_counts: Optional[dict[str, int]] = None
 
     @classmethod
     def from_vespa_response(cls, response_hit: dict) -> "Hit":
@@ -485,6 +483,8 @@ class Hit(BaseModel):
 class Document(Hit):
     """A document search result hit."""
 
+    concept_counts: Optional[dict[str, int]] = None
+
     @classmethod
     def from_vespa_response(cls, response_hit: dict) -> "Document":
         """
@@ -519,7 +519,6 @@ class Document(Hit):
             corpus_type_name=fields.get("corpus_type_name"),
             corpus_import_id=fields.get("corpus_import_id"),
             metadata=fields.get("metadata"),
-            concepts=fields.get("concepts"),
             relevance=response_hit.get("relevance"),
             rank_features=fields.get("summaryfeatures"),
             concept_counts=fields.get("concept_counts"),
@@ -534,6 +533,7 @@ class Passage(Hit):
     text_block_type: str
     text_block_page: Optional[int] = None
     text_block_coords: Optional[Sequence[tuple[float, float]]] = None
+    concepts: Optional[Sequence[Concept]] = None
 
     @classmethod
     def from_vespa_response(cls, response_hit: dict) -> "Passage":

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
 _MINOR = "16"
-_PATCH = "1"
+_PATCH = "2"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)


### PR DESCRIPTION
# Description

This led to confusion when interacting with the hits, in that passages seemed to have `concept_counts` and documents, `concepts`. Moving both to just be on the child object instead makes it clearer the distinction between them

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
