### PR TITLE
fix: make `conceptsfilter` filter against the list of concepts not a singular concept

### DIFF
--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,4 +1,4 @@
-_MAJOR = "1"
+_MAJOR = "2"
 _MINOR = "16"
 _PATCH = "3"
 _SUFFIX = ""

--- a/src/cpr_sdk/yql_builder.py
+++ b/src/cpr_sdk/yql_builder.py
@@ -2,6 +2,7 @@ from string import Template
 from typing import Optional
 
 from rich import print as rprint
+
 from cpr_sdk.models.search import Filters, SearchParameters
 
 
@@ -94,15 +95,25 @@ class YQLBuilder:
         return None
 
     def build_concepts_filter(self) -> Optional[str]:
-        """Create the part of the query that limits to specific concepts"""
+        """
+        Create the part of the query that limits to specific concepts.
+
+        e.g:
+        - `concepts.name contains 'floods' and concepts.name contains 'environment'`
+        - `concepts.parent_concept_ids_flat matches 'Q123' and concepts.name contains 'environment'`
+        """
         if self.params.concept_filters:
             concepts_query = []
             for concept in self.params.concept_filters:
                 if concept.name == "parent_concept_ids_flat":
-                    concepts_query.append(f"{concept.name} matches '{concept.value}'")
+                    concepts_query.append(
+                        f"concepts.{concept.name} matches '{concept.value}'"
+                    )
                 else:
-                    concepts_query.append(f"{concept.name} contains '{concept.value}'")
-            return f"(concepts contains sameElement({', '.join(concepts_query)}))"
+                    concepts_query.append(
+                        f"concepts.{concept.name} contains '{concept.value}'"
+                    )
+            return f"({' and '.join(concepts_query)})"
         return None
 
     def build_corpus_type_name_filter(self) -> Optional[str]:

--- a/tests/test_search_adaptors.py
+++ b/tests/test_search_adaptors.py
@@ -559,6 +559,13 @@ def test_vespa_search_adaptor__corpus_type_name(
     [
         (
             "the",
+            [
+                {"name": "name", "value": "floods"},
+                {"name": "name", "value": "environment"},
+            ],
+        ),
+        (
+            "the",
             [{"name": "name", "value": "environment"}],
         ),
         (


### PR DESCRIPTION
# Description

TL;DR: we used to use the `list[ConceptFilter]` to filter against a singular concept, now we use those to filter against the list of concepts on a passage.

Currently the `list[ConceptFilter]` generates a filter that queries against a singular filter. e.g. 
```python
list(ConceptFilter(name=floods), ConceptFilter(name=environment))

# generates
(concepts contains sameElement(name = 'floods', name = 'environment'))
```

Looking at the [`sameElement` docs](https://docs.vespa.ai/en/reference/query-language-reference.html#sameelement) - we can assume that's saying "Give us a passage with a concept with the name 'floods' and the name 'environment'".

## This change
```python
list(ConceptFilter(name=floods), ConceptFilter(name=environment))

# generates
(concepts.name contains 'floods' and concepts.name = 'environment')
```

Which can be read as "Give us a passage where it has a concept with a name 'floods' and a concept with name 'environment'".


## Proposed version

- [x] Major version

## Type of change

Please select the option(s) below that are most relevant:

- [x] Breaking change

## How Has This Been Tested?

The tests have been updated to include this use case above.

All previous use cases are still valid.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

Part of https://linear.app/climate-policy-radar/issue/APP-294/fix-multiple-concept-search-in-backend
