### PR TITLE
align search tests with Vespa storing deleted and unpublished documents

### DIFF
--- a/docs/search/4_search_intention_tests.md
+++ b/docs/search/4_search_intention_tests.md
@@ -4,6 +4,11 @@ The command `make test_search_intentions` runs a set of pytest tests that run qu
 
 These were adapted from [wellcomecollection/rank](https://github.com/wellcomecollection/rank).
 
+> [!WARNING]
+> Results from directly querying Vespa won't always be the same as those in the user-facing apps. This is because the apps only show documents that have been published and not deleted. Vespa has no field storing published status, and the pipeline that populates it is write-only.
+>
+> What this means in practice is that some failing tests could pass in our tools, or vice-versa. There's currently no way of handing this in the tests themselves, so use your best judgement as to how to adapt the test to exclude documents that are in Vespa but not in our tools.
+
 ## What are these tests for?
 
 In an ideal world, we'll maintain a collection of search queries we know about and the kinds of results they should return. These could be from users, analytics or dogfooding our own apps. We should also collect a list of search intentions for each new data corpus or custom app.

--- a/tests/search_intentions/test_top_families.py
+++ b/tests/search_intentions/test_top_families.py
@@ -28,8 +28,8 @@ test_cases = [
         known_failure=True,
     ),
     TopFamiliesTestCase(
-        search_terms="egypt national climate change strategy",
-        expected_family_slugs=["egypt-national-climate-change-strategy-nccs-2050_d3b1"],
+        search_terms="National Climate Change Strategy 2021-2026",
+        expected_family_slugs=["national-climate-change-strategy-2021-2026_50bb"],
         description="Searching for the family title should return the correct family.",
     ),
     TopFamiliesTestCase(


### PR DESCRIPTION
# Description

Vespa's documents and families are not the same as those in the app – see [Slack discussion](https://climate-policy-radar.slack.com/archives/C078UT6R8GK/p1740394509870239). 

In this PR:

- adds a note explaining this to the docs
- fixes the test that was failing as a result of this issue

Stacking on top of #187 which adds data science as a codeowner for these files.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
