### PR TITLE
spike encoding in vespa (local)

### DIFF
--- a/src/cpr_sdk/yql_builder.py
+++ b/src/cpr_sdk/yql_builder.py
@@ -69,7 +69,7 @@ class YQLBuilder:
                     (userInput(@query_string)) 
                     or (
                         [{"targetNumHits": 1000}]
-                        nearestNeighbor(text_embedding,query_embedding)
+                        nearestNeighbor(auto_text_embedding,query_embedding)
                     )
                 )
             """

--- a/tests/local_vespa/test_app/schemas/document_passage.sd
+++ b/tests/local_vespa/test_app/schemas/document_passage.sd
@@ -187,12 +187,12 @@ schema document_passage {
             query(passage_closeness_weight) double: 1.0
         }
         function text_score() {
-            expression: query(passage_bm25_weight) * bm25(text_block) + query(passage_closeness_weight) * closeness(text_embedding)
+            expression: query(passage_bm25_weight) * bm25(text_block) + query(passage_closeness_weight) * closeness(auto_text_embedding)
         }
         first-phase {
             expression: query(passage_weight) * text_score()
         }
-        summary-features: text_score() bm25(text_block) closeness(text_embedding) query(passage_weight)
+        summary-features: text_score() bm25(text_block) closeness(auto_text_embedding) query(passage_weight)
     }
     
     rank-profile hybrid_nativerank inherits default_passage {
@@ -202,12 +202,12 @@ schema document_passage {
             query(passage_closeness_weight) double: 1.0
         }
         function text_score() {
-            expression: query(passage_nativerank_weight) * nativeRank(text_block) + query(passage_closeness_weight) * closeness(text_embedding)
+            expression: query(passage_nativerank_weight) * nativeRank(text_block) + query(passage_closeness_weight) * closeness(auto_text_embedding)
         }
         first-phase {
             expression: query(passage_weight) * text_score()
         }
-        summary-features: text_score() nativeRank(text_block) closeness(text_embedding) query(passage_weight)
+        summary-features: text_score() nativeRank(text_block) closeness(auto_text_embedding) query(passage_weight)
     }
 
     rank-profile hybrid_no_closeness inherits hybrid {

--- a/tests/local_vespa/test_app/schemas/document_passage.sd
+++ b/tests/local_vespa/test_app/schemas/document_passage.sd
@@ -9,6 +9,21 @@ schema document_passage {
         stemming: none
     }
 
+    field auto_text_embedding type tensor<bfloat16>(x[768]) {
+        indexing {
+            input text_block | embed msmarco-distilbert-dot-v5 | attribute | index
+        }
+        attribute {
+            distance-metric: innerproduct
+        }
+        index {
+            hnsw {
+                max-links-per-node: 16
+                neighbors-to-explore-at-insert: 500
+            }
+        }
+    }
+
     document document_passage {
 
         field search_weights_ref type reference<search_weights> {


### PR DESCRIPTION
# Description

## Changes

Two small changes:
- add encoding to vespa
- swap query to use new embeddings field

## Results

### Indexing 

Indexing took 56 seconds. There were lots of `429: too many requests` responses until I upgraded my local Vespa CLI to a version that apparently handles throttling better (see [related issue](https://github.com/vespa-engine/vespa/issues/31798#issuecomment-2202857864)). The version of the Vespa CLI that produced this result is `8.420.10`.

```
vespa feed tests/local_vespa/test_documents/document_passage.json
{
  "feeder.operation.count": 1965,
  "feeder.seconds": 55.860,
  "feeder.ok.count": 1965,
  "feeder.ok.rate": 35.178,
  "feeder.error.count": 0,
  "feeder.inflight.count": 0,
  "http.request.count": 1965,
  "http.request.bytes": 17064770,
  "http.request.MBps": 0.305,
  "http.exception.count": 0,
  "http.response.count": 1965,
  "http.response.bytes": 311524,
  "http.response.MBps": 0.006,
  "http.response.error.count": 0,
  "http.response.latency.millis.min": 90,
  "http.response.latency.millis.avg": 528,
  "http.response.latency.millis.max": 3307,
  "http.response.code.counts": {
    "200": 1965
  }
}
```

### Search

It works! There'll be a bit of rank profile blue-greening the first time around to swap over the embeddings field but I don't think that's a bad thing.

<img width="1784" alt="image" src="https://github.com/user-attachments/assets/f7cef3c9-3ce5-4771-a7cd-3d9eb0fc1c1b" />
