### PR TITLE
enable filtering by concept ids in the search CLI

### DIFF
--- a/src/cpr_sdk/cli/search.py
+++ b/src/cpr_sdk/cli/search.py
@@ -6,7 +6,13 @@ from rich.table import Table
 from rich.markdown import Markdown
 import typer
 from cpr_sdk.search_adaptors import VespaSearchAdapter
-from cpr_sdk.models.search import SearchParameters, Passage, Document, SearchResponse
+from cpr_sdk.models.search import (
+    SearchParameters,
+    Passage,
+    Document,
+    SearchResponse,
+    ConceptFilter,
+)
 from cpr_sdk.vespa import build_vespa_request_body, parse_vespa_response
 from cpr_sdk.config import VESPA_URL
 
@@ -55,12 +61,23 @@ def main(
             help="Whether to include tokens in the summary. Tokens are not in the final Vespa response model, so this requires setting a breakpoint on the raw response."
         ),
     ] = False,
+    concept_id: Annotated[
+        list[str],
+        typer.Option(
+            help="Filter results by concept ID. Can be used multiple times in the same run."
+        ),
+    ] = [],
 ):
     """Run a search query with different rank profiles."""
     console = Console()
     search_adapter = VespaSearchAdapter(VESPA_URL)
     search_parameters = SearchParameters(
-        query_string=query, exact_match=exact_match, limit=limit
+        query_string=query,
+        exact_match=exact_match,
+        limit=limit,
+        concept_filters=[
+            ConceptFilter(name="id", value=concept_id) for concept_id in concept_id
+        ],
     )
     request_body = build_vespa_request_body(search_parameters)
 

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
 _MINOR = "17"
-_PATCH = "1"
+_PATCH = "2"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)


### PR DESCRIPTION
# Description

Quick addition to the search CLI to help us reproduce and debug searches.

E.g. `poetry run python -m src.cpr_sdk.cli.search "climate" --concept-id Q1286 --concept-id Q374` gives you this, with passage level results per family below

<img width="1478" alt="image" src="https://github.com/user-attachments/assets/c6a165e9-e814-4324-8c9e-dfe42f888ac3" />

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
