### PR TITLE
Feature/app 319 order of results on document search

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ This requires the [vespa cli](https://docs.vespa.ai/en/vespa-cli.html) to be ins
 
 Setup can then be run with:
 
-```
+```bash
 make install
 make vespa_dev_setup
 make test
@@ -227,13 +227,13 @@ make test
 
 Alternatively, to only run non-vespa tests:
 
-```
+```bash
 make test_not_vespa
 ```
 
 For clean up:
 
-```
+```bash
 make vespa_dev_down
 ```
 

--- a/src/cpr_sdk/models/search.py
+++ b/src/cpr_sdk/models/search.py
@@ -26,6 +26,7 @@ sort_fields = {
     "title": "family_name",
     "name": "family_name",
     "concept_counts": "concept_counts.value",
+    "page_number": "text_block_page"
 }
 
 filter_fields = {

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
 _MINOR = "17"
-_PATCH = "1"
+_PATCH = "2"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
-_MINOR = "17"
-_PATCH = "2"
+_MINOR = "18"
+_PATCH = "0"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)


### PR DESCRIPTION
# Description

Add new sort field `page_number` (that maps to `text_block_page` in the vespa schema) to the sdk, so that we can show passage matches in chronological order of how they appear in a document in the frontend.

This is motivated by policy testing of the most recent KG developments.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [x] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## How Has This Been Tested?

Covered using the existing test tests/test_search_adaptors.py::test_vespa_search_adapter_sorting

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
