### PR TITLE
add distance threshold to vespa queries

### DIFF
--- a/src/cpr_sdk/cli/search.py
+++ b/src/cpr_sdk/cli/search.py
@@ -6,7 +6,6 @@ import typer
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.table import Table
-from typing_extensions import Annotated
 
 from cpr_sdk.config import VESPA_URL
 from cpr_sdk.models.search import (
@@ -52,34 +51,22 @@ def main(
     exact_match: bool = False,
     limit: int = 20,
     show_rank_features: bool = False,
-    page_results: Annotated[
-        bool,
-        typer.Option(
-            default=True,
-            help="Whether to use the default terminal pager to show results. Disable with `--no-page-results` if you want to redirect the output to a file.",
-        ),
-    ] = True,
-    experimental_tokens: Annotated[
-        bool,
-        typer.Option(
-            default=False,
-            help="Whether to include tokens in the summary. Tokens are not in the final Vespa response model, so this requires setting a breakpoint on the raw response.",
-        ),
-    ] = False,
-    concept_id: Annotated[
-        list[str],
-        typer.Option(
-            default=[],
-            help="Filter results by concept ID. Can be used multiple times in the same run.",
-        ),
-    ] = [],
-    distance_threshold: Annotated[
-        Optional[float],
-        typer.Option(
-            default=None,
-            help="Optional threshold for the vector component of hybrid search. Passages with an inner product score below this threshold will be excluded.",
-        ),
-    ] = None,
+    page_results: bool = typer.Option(
+        default=True,
+        help="Whether to use the default terminal pager to show results. Disable with `--no-page-results` if you want to redirect the output to a file.",
+    ),
+    experimental_tokens: bool = typer.Option(
+        default=False,
+        help="Whether to include tokens in the summary. Tokens are not in the final Vespa response model, so this requires setting a breakpoint on the raw response.",
+    ),
+    concept_id: list[str] = typer.Option(
+        default=[],
+        help="Filter results by concept ID. Can be used multiple times in the same run.",
+    ),
+    distance_threshold: Optional[float] = typer.Option(
+        default=None,
+        help="Optional threshold for the vector component of hybrid search. Passages with an inner product score below this threshold will be excluded.",
+    ),
 ):
     """Run a search query with different rank profiles."""
     console = Console()

--- a/src/cpr_sdk/models/search.py
+++ b/src/cpr_sdk/models/search.py
@@ -316,6 +316,13 @@ class SearchParameters(BaseModel):
     See docs: https://docs.vespa.ai/en/query-rewriting.html#rule-bases
     """
 
+    distance_threshold: Optional[float] = None
+    """
+    Optional threshold for the nearest neighbor search distance. Results with a
+    distance score below this threshold will be excluded. Based on the 'innerproduct'
+    distance metric, lower scores are less relevant.
+    """
+
     @model_validator(mode="after")
     def validate(self):
         """Validate against mutually exclusive fields"""

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
 _MINOR = "18"
-_PATCH = "2"
+_PATCH = "3"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)

--- a/tests/test_yql_builder.py
+++ b/tests/test_yql_builder.py
@@ -2,12 +2,12 @@ import pytest
 from vespa.exceptions import VespaError
 
 from cpr_sdk.models.search import (
+    ConceptCountFilter,
     Filters,
+    OperandTypeEnum,
     SearchParameters,
     sort_fields,
     sort_orders,
-    ConceptCountFilter,
-    OperandTypeEnum,
 )
 from cpr_sdk.vespa import VespaErrorDetails
 from cpr_sdk.yql_builder import YQLBuilder
@@ -208,3 +208,20 @@ def test_yql_builder_build_concept_count_filter() -> None:
     assert concept_count_filter_clause.replace("  ", "").replace("\n", "") == (
         '((concept_counts contains sameElement(key contains "concept_1_1", value = 101)))'
     )
+
+
+def test_distance_threshold_appears_in_yql():
+    """Test whether the distance_threshold clause appears in the YQL when specified."""
+    # Test with distance_threshold set
+    threshold = 0.7
+    params_with_threshold = SearchParameters(
+        query_string="test", distance_threshold=threshold
+    )
+    yql_with_threshold = YQLBuilder(params_with_threshold).to_str()
+    expected_substring = f'"distanceThreshold": {threshold}'
+    assert expected_substring in yql_with_threshold
+
+    # Test without distance_threshold (default is None)
+    params_without_threshold = SearchParameters(query_string="test")
+    yql_without_threshold = YQLBuilder(params_without_threshold).to_str()
+    assert "distanceThreshold" not in yql_without_threshold


### PR DESCRIPTION
This PR adds a `distance_threshold` parameter to the `SearchParameters` class, which, if specified, is used by the `YQLBuilder` to add an appropriate `distanceThreshold` clause to the query. See [the vespa docs](https://docs.vespa.ai/en/nearest-neighbor-search-guide.html) for more info on how the clause affects behaviour.

I've also added a test for the presence of the clause in the query depending on user input, and the option to specify a threshold when using the search CLI.

I've confirmed that adding a threshold to a query does make a difference to the number of returned passages, and have started a bit of qualitative evaluation of the results by running queries through the search CLI. However, the value of the threshold that we apply doesn't seem to map neatly onto where vespa sets the threshold on the `closeness(text_embedding)` score... I have a feeling that this is related to how our schema is set up, but I still haven't figured out all of the details here.

Given the number of degrees of freedom here and the need to develop better heuristics/intuition around vespa behaviour, I'm going to leave it to another PR (tomorrow?) to add a suite of tests which motivate a good default threshold. This PR just adds the functionality.

also closes SCI-257