### PR TITLE
add a field for document identifiers

### DIFF
--- a/src/cpr_sdk/yql_builder.py
+++ b/src/cpr_sdk/yql_builder.py
@@ -74,11 +74,12 @@ class YQLBuilder:
 
             return f"""
                 (
-                    (userInput(@query_string)) 
+                    (userInput(@query_string))
                     or (
                         [{{\"targetNumHits\": 1000{distance_threshold_clause}}}]
                         nearestNeighbor(text_embedding,query_embedding)
                     )
+                    or (document_identifiers contains @query_string)
                 )
             """
 

--- a/tests/local_vespa/test_app/schemas/family_document.sd
+++ b/tests/local_vespa/test_app/schemas/family_document.sd
@@ -125,6 +125,12 @@ schema family_document {
             indexing: summary | attribute
         }
 
+        field document_identifiers type array<string> {
+            indexing: attribute | index
+            match: exact
+            attribute: fast-search
+        }
+
         field corpus_import_id type string {
             indexing: summary | attribute
             attribute: fast-search
@@ -201,6 +207,10 @@ schema family_document {
             query(description_bm25_weight) double: 1.0
             query(description_closeness_weight) double: 1.0
         }
+        function identifier_boost_score() {
+            # Huge score if any query term exactly matches an identifier
+            expression: matches(document_identifiers) * 1E9
+        }
         function name_score() {
             expression: bm25(family_name_index)
         }
@@ -208,9 +218,9 @@ schema family_document {
             expression: query(description_bm25_weight) * bm25(family_description_index) + query(description_closeness_weight) * closeness(family_description_embedding)
         }
         first-phase {
-            expression: (query(name_weight) * name_score()) + (query(description_weight) * description_score())
+            expression: identifier_boost_score() + (query(name_weight) * name_score()) + (query(description_weight) * description_score())
         }
-        summary-features: name_score() description_score() bm25(family_name_index) bm25(family_description_index) closeness(family_description_embedding)
+        summary-features: name_score() description_score() bm25(family_name_index) bm25(family_description_index) closeness(family_description_embedding) identifier_boost_score()
     }
     
     rank-profile hybrid_nativerank inherits default_family {
@@ -219,6 +229,10 @@ schema family_document {
             query(description_nativerank_weight) double: 1.0
             query(description_closeness_weight) double: 1.0
         }
+        function identifier_boost_score() {q
+            # Huge score if any query term exactly matches an identifier
+            expression: matches(document_identifiers) * 1E9
+        }
         function name_score() {
             expression: nativeRank(family_name_index)
         }
@@ -226,9 +240,9 @@ schema family_document {
             expression: query(description_nativerank_weight) * nativeRank(family_description_index) + query(description_closeness_weight) * closeness(family_description_embedding)
         }
         first-phase {
-            expression: (query(name_weight) * name_score()) + (query(description_weight) * description_score())
+            expression: identifier_boost_score() + (query(name_weight) * name_score()) + (query(description_weight) * description_score())
         }
-        summary-features: name_score() description_score() nativeRank(family_name_index) nativeRank(family_description_index) closeness(family_description_embedding)
+        summary-features: name_score() description_score() nativeRank(family_name_index) nativeRank(family_description_index) closeness(family_description_embedding) identifier_boost_score()
     }
 
     rank-profile hybrid_no_closeness inherits hybrid {

--- a/tests/local_vespa/test_app/schemas/family_document.sd
+++ b/tests/local_vespa/test_app/schemas/family_document.sd
@@ -229,7 +229,7 @@ schema family_document {
             query(description_nativerank_weight) double: 1.0
             query(description_closeness_weight) double: 1.0
         }
-        function identifier_boost_score() {q
+        function identifier_boost_score() {
             # Huge score if any query term exactly matches an identifier
             expression: matches(document_identifiers) * 1E9
         }


### PR DESCRIPTION
This PR:

- adds a `document_identifiers` field to our `family_document` schema, which should be populated with any IDs we'd like to make searchable, eg internal document ingest IDs, litigation docket numbers, etc
- adds a new corresponding score to our rank profiles (`identifier_boost_score`). This adds a _massive_ boost to any document ID which is matched by a term in the user's query. These hits should be very rare (ie almost all searches will be unaffected), but when they do, the huge score should ensure that the document with the matching ID is pushed to the top of the list of results.
- adds a clause to the YQL builder to ensure that we're retrieving docs (not just scoring them) according to matches on the contents of `document_identifiers`

I think these changes give us what we need to meet the following requirements against an indexed document with `abc.123.blah.blah` in the `document_identifiers` field:

| User's search terms | Matched |
|-----------------------------------------------------------|-----------------------------------------------------------------------------------|
| "abc.123.blah.blah" | ✅ |
| "abc.123.blah.blah and also i'm interested in cows" | ✅ |
| "abc" |  ❌ |
| "ABC.123.BLAH.BLAH" | ✅ |

NB despite being theoretically reasonable (I think), this solution is untested so far, and needs a set of corresponding changes to https://github.com/climatepolicyradar/navigator-data-ingest to get the new field populated with real data! 

I think I'll also need a hand from @climatepolicyradar/deng with shepherding this change through to the actual prod index - I'm not sure exactly how much auto-deploy magic we have in place, or how disruptive an addition like this might be.

Also part of the solution for SCI-367