### PR TITLE
implement concept and model filtering

### DIFF
--- a/src/cpr_sdk/models/search.py
+++ b/src/cpr_sdk/models/search.py
@@ -352,8 +352,9 @@ class SearchParameters(BaseModel):
         return self
 
     @model_validator(mode="after")
-    def concept_filters_not_set_if_documents_only(self) -> Self:
-        """Ensure concept_filters are not set if browse mode (documents_only) is set."""
+    def validate_concept_filters(self) -> Self:
+        """Validate concept filters"""
+        # Ensure concept_filters are not set if browse mode (documents_only) is set.
         if (
             any([self.concept_filters, self.concept_and_model_filters])
             and self.documents_only is True
@@ -361,11 +362,8 @@ class SearchParameters(BaseModel):
             raise ValueError(
                 "Cannot set concept_filters or concept_and_model_filters when only searching documents. This is as concept_filters are only applicable to passages."
             )
-        return self
 
-    @model_validator(mode="after")
-    def concept_filters_and_concept_model_filters_mutually_exclusive(self) -> Self:
-        """Ensure that both concept_filters and concept_model_filters are not set."""
+        # Ensure that both concept_filters and concept_model_filters are not set.
         if self.concept_filters and self.concept_and_model_filters:
             raise ValueError(
                 "Cannot set both concept_filters and concept_model_filters. Use one or the other."

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
-_MINOR = "18"
-_PATCH = "3"
+_MINOR = "19"
+_PATCH = "0"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)

--- a/src/cpr_sdk/yql_builder.py
+++ b/src/cpr_sdk/yql_builder.py
@@ -124,6 +124,17 @@ class YQLBuilder:
             return f"({' and '.join(concepts_query)})"
         return None
 
+    def build_concept_and_model_filter(self) -> Optional[str]:
+        """Create the part of the query that limits to specific concepts with model versions."""
+        if self.params.concept_and_model_filters:
+            concepts_model_query = []
+            for concept in self.params.concept_and_model_filters:
+                concepts_model_query.append(
+                    f"concepts contains sameElement({concept.concept_field} contains('{concept.value}'), model contains('{concept.model}'))"
+                )
+            return f"({' and '.join(concepts_model_query)})"
+        return None
+
     def build_corpus_type_name_filter(self) -> Optional[str]:
         """Create the part of the query that limits to specific corpora"""
         if self.params.corpus_type_names:
@@ -212,6 +223,7 @@ class YQLBuilder:
         filters.append(self.build_corpus_import_ids_filter())
         filters.append(self.build_metadata_filter())
         filters.append(self.build_concepts_filter())
+        filters.append(self.build_concept_and_model_filter())
         if f := self.params.filters:
             filters.append(self._inclusive_filters(f, "family_geographies"))
             filters.append(self._inclusive_filters(f, "family_geography"))

--- a/tests/local_vespa/test_app/schemas/document_passage.sd
+++ b/tests/local_vespa/test_app/schemas/document_passage.sd
@@ -72,7 +72,8 @@ schema document_passage {
 
         field concepts type array<concept> {
             indexing: summary
-
+            summary:  matched-elements-only
+            
             struct-field name {
                 indexing: attribute
             }

--- a/tests/test_search_adaptors.py
+++ b/tests/test_search_adaptors.py
@@ -708,7 +708,17 @@ def test_vespa_search_adaptor__concept_and_model_filter(
                 [isinstance(concept_hit, Concept) for concept_hit in hit.concepts]
             )
 
+            specified_models = [
+                concept_filter["model"] for concept_filter in concept_and_model_filters
+            ]
+
+            # Only concepts with the specified models should be present
+            assert all(
+                concept_hit.model in specified_models for concept_hit in hit.concepts
+            )
+
             for concept_filter in concept_and_model_filters:
+                # Find the concepts with the same model and name/id as the filter
                 field_name = concept_filter["concept_field"]
                 hit_concept_filter_vals = [
                     concept.__getattribute__(field_name)
@@ -716,12 +726,7 @@ def test_vespa_search_adaptor__concept_and_model_filter(
                     if concept.model == concept_filter["model"]
                 ]
 
-                assert any(
-                    [
-                        hit_concept_filter_val == concept_filter["value"]
-                        for hit_concept_filter_val in hit_concept_filter_vals
-                    ]
-                )
+                assert len(hit_concept_filter_vals) > 0
 
 
 @pytest.mark.vespa

--- a/tests/test_search_parameters.py
+++ b/tests/test_search_parameters.py
@@ -19,7 +19,7 @@ from cpr_sdk.models.search import SearchParameters
                 "concept_filters": [{"name": "name", "value": "environment"}],
             },
             True,
-            "Cannot set concept_filters when only searching documents.",
+            "Cannot set concept_filters or concept_and_model_filters when only searching documents.",
         ),
         (
             {

--- a/tests/test_yql_builder.py
+++ b/tests/test_yql_builder.py
@@ -2,6 +2,7 @@ import pytest
 from vespa.exceptions import VespaError
 
 from cpr_sdk.models.search import (
+    ConceptAndModelFilter,
     ConceptCountFilter,
     Filters,
     OperandTypeEnum,
@@ -225,3 +226,22 @@ def test_distance_threshold_appears_in_yql():
     params_without_threshold = SearchParameters(query_string="test")
     yql_without_threshold = YQLBuilder(params_without_threshold).to_str()
     assert "distanceThreshold" not in yql_without_threshold
+
+
+def test_yql_builder_build_concept_and_model_filter():
+    """Test that the concept and model filter is built correctly."""
+    params = SearchParameters(
+        concept_and_model_filters=[
+            ConceptAndModelFilter(
+                concept_field="name", value="floods", model="shiny-new-model-yay"
+            ),
+            ConceptAndModelFilter(
+                concept_field="id", value="Q123", model="q123-model-from-tuesday"
+            ),
+        ]
+    )
+    yql = YQLBuilder(params).build_concept_and_model_filter()
+    assert (
+        yql
+        == "(concepts contains sameElement(name contains('floods'), model contains('shiny-new-model-yay')) and concepts contains sameElement(id contains('Q123'), model contains('q123-model-from-tuesday')))"
+    )


### PR DESCRIPTION
# Description

Adds `YQLBuilder.build_concept_and_model_filter()` which enables specifying concepts by their name and ID with a specific model. E.g.

``` py
concept_and_model_filters = [
    {
        "concept_field": "name",
        "value": "environment",
        "model": "fancy-new-model-uuid",
    },
    # or
    {
        "concept_field": "id",
        "value": "Q123",
        "model": "another-model-uuid",
    },
]
```

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [x] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
