### PR TITLE
Updating the content type validation method.

### DIFF
--- a/src/cpr_sdk/parser_models.py
+++ b/src/cpr_sdk/parser_models.py
@@ -200,12 +200,13 @@ class BaseParserOutput(BaseModel):
         are both null.
         """
 
-        if self.document_content_type not in {
-            CONTENT_TYPE_HTML,
-            CONTENT_TYPE_PDF,
-        } and (self.html_data is not None or self.pdf_data is not None):
+        document_has_data = (
+            self.html_data is not None or self.pdf_data is not None
+        )
+
+        if not self.document_content_type and document_has_data:
             raise ValueError(
-                "html_data and pdf_data must be null for documents with no content type."
+                "html_data or pdf_data must be null for documents with no content type."
             )
 
         return self

--- a/src/cpr_sdk/parser_models.py
+++ b/src/cpr_sdk/parser_models.py
@@ -8,7 +8,6 @@ from typing import Any, Final, List, Optional, Sequence, Tuple, TypeVar, Union
 
 from cpr_sdk.pipeline_general_models import (
     CONTENT_TYPE_HTML,
-    CONTENT_TYPE_PDF,
     BackendDocument,
     Json,
 )
@@ -200,9 +199,7 @@ class BaseParserOutput(BaseModel):
         are both null.
         """
 
-        document_has_data = (
-            self.html_data is not None or self.pdf_data is not None
-        )
+        document_has_data = self.html_data is not None or self.pdf_data is not None
 
         if not self.document_content_type and document_has_data:
             raise ValueError(

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
 _MINOR = "19"
-_PATCH = "0"
+_PATCH = "1"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)

--- a/tests/test_parser_models.py
+++ b/tests/test_parser_models.py
@@ -67,7 +67,7 @@ def test_parser_output_object(
     with pytest.raises(pydantic.ValidationError) as context:
         ParserOutput.model_validate(parser_output_no_content_type)
     assert (
-        "html_data and pdf_data must be null for documents with no content type."
+        "html_data or pdf_data must be null for documents with no content type."
     ) in str(context.value)
 
     # Test the can construct a parser output with content type ms word with pdf data.

--- a/tests/test_parser_models.py
+++ b/tests/test_parser_models.py
@@ -71,8 +71,8 @@ def test_parser_output_object(
     ) in str(context.value)
 
     # Test the can construct a parser output with content type ms word with pdf data.
-    parser_output_ms_w = parser_output_json_pdf.copy()
-    parser_output_ms_w["document_content_type"] = "application/msword"
+    parser_output_ms_word = parser_output_json_pdf.copy()
+    parser_output_ms_word["document_content_type"] = "application/msword"
 
     ParserOutput.model_validate(parser_output_empty_fields)
 

--- a/tests/test_parser_models.py
+++ b/tests/test_parser_models.py
@@ -60,8 +60,8 @@ def test_parser_output_object(
     parser_output_no_html_data["html_data"] = None
     parser_output_no_html_data["document_content_type"] = CONTENT_TYPE_HTML
 
-    parser_output_no_content_type = parser_output_json_pdf.copy()
     # PDF data is set as the default
+    parser_output_no_content_type = parser_output_json_pdf.copy()
     parser_output_no_content_type["document_content_type"] = None
 
     with pytest.raises(pydantic.ValidationError) as context:
@@ -70,8 +70,14 @@ def test_parser_output_object(
         "html_data and pdf_data must be null for documents with no content type."
     ) in str(context.value)
 
-    parser_output_not_known_content_type = parser_output_json_pdf.copy()
+    # Test the can construct a parser output with content type ms word with pdf data.
+    parser_output_ms_w = parser_output_json_pdf.copy()
+    parser_output_ms_w["document_content_type"] = "application/msword"
+
+    ParserOutput.model_validate(parser_output_empty_fields)
+
     # PDF data is set as the default
+    parser_output_not_known_content_type = parser_output_json_pdf.copy()
     parser_output_not_known_content_type["document_content_type"] = "not_known"
 
     with pytest.raises(pydantic.ValidationError) as context:

--- a/tests/test_parser_models.py
+++ b/tests/test_parser_models.py
@@ -70,21 +70,11 @@ def test_parser_output_object(
         "html_data or pdf_data must be null for documents with no content type."
     ) in str(context.value)
 
-    # Test the can construct a parser output with content type ms word with pdf data.
-    parser_output_ms_word = parser_output_json_pdf.copy()
-    parser_output_ms_word["document_content_type"] = "application/msword"
-
-    ParserOutput.model_validate(parser_output_empty_fields)
-
     # PDF data is set as the default
     parser_output_not_known_content_type = parser_output_json_pdf.copy()
-    parser_output_not_known_content_type["document_content_type"] = "not_known"
+    parser_output_not_known_content_type["document_content_type"] = "application/msword"
 
-    with pytest.raises(pydantic.ValidationError) as context:
-        ParserOutput.model_validate(parser_output_not_known_content_type)
-    assert (
-        "html_data and pdf_data must be null for documents with no content type."
-    ) in str(context.value)
+    ParserOutput.model_validate(parser_output_not_known_content_type)
 
     # Test the text blocks property
     assert ParserOutput.model_validate(parser_output_json_pdf).text_blocks != []


### PR DESCRIPTION
# Description

Updating the validation method on the `BaseParserOutput` object post changes to the ingest logic. We now allow documents to have pdf data even if the content type is not `application/pdf`. This is as we are converting word docs to pdfs and want to persist the original content type of the source document. 

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [X] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Unit tests in this repo. 

