### PR TITLE
Failing test for 500 errors when filters contain apostrophes

### DIFF
--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
 _MINOR = "23"
-_PATCH = "2"
+_PATCH = "3"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)

--- a/src/cpr_sdk/yql_builder.py
+++ b/src/cpr_sdk/yql_builder.py
@@ -39,10 +39,10 @@ class YQLBuilder:
         self.sensitive = sensitive
 
     def _escape_yql_literal(self, value: Optional[str]) -> str:
-        """Escape a Python string for safe inclusion in a single-quoted YQL literal."""
+        """Escape a apostrophes for safe inclusion in a single-quoted YQL literal."""
         if value is None:
             return ""
-        return value.replace("\\", "\\\\").replace("'", "\\'")
+        return value.replace("'", "\\'")
 
     def build_sources(self) -> str:
         """Creates the part of the query that determines which sources to search"""

--- a/src/cpr_sdk/yql_builder.py
+++ b/src/cpr_sdk/yql_builder.py
@@ -38,7 +38,7 @@ class YQLBuilder:
         self.params = params
         self.sensitive = sensitive
 
-    def _escape_yql_literal(self, value: Optional[str]) -> str:
+    def _escape_apostrophes(self, value: Optional[str]) -> str:
         """Escape a apostrophes for safe inclusion in a single-quoted YQL literal."""
         if value is None:
             return ""

--- a/src/cpr_sdk/yql_builder.py
+++ b/src/cpr_sdk/yql_builder.py
@@ -99,8 +99,8 @@ class YQLBuilder:
         metadata_filters = []
         if self.params.metadata:
             for metadata in self.params.metadata:
-                name_escaped = self._escape_yql_literal(metadata.name)
-                value_escaped = self._escape_yql_literal(metadata.value)
+                name_escaped = self._escape_apostrophes(metadata.name)
+                value_escaped = self._escape_apostrophes(metadata.value)
                 metadata_filters.append(
                     f"""
                     (

--- a/src/cpr_sdk/yql_builder.py
+++ b/src/cpr_sdk/yql_builder.py
@@ -38,6 +38,12 @@ class YQLBuilder:
         self.params = params
         self.sensitive = sensitive
 
+    def _escape_yql_literal(self, value: Optional[str]) -> str:
+        """Escape a Python string for safe inclusion in a single-quoted YQL literal."""
+        if value is None:
+            return ""
+        return value.replace("\\", "\\\\").replace("'", "\\'")
+
     def build_sources(self) -> str:
         """Creates the part of the query that determines which sources to search"""
         if self.params.documents_only:
@@ -92,19 +98,19 @@ class YQLBuilder:
         """Create the part of the query that limits to specific metadata"""
         metadata_filters = []
         if self.params.metadata:
-            [
+            for metadata in self.params.metadata:
+                name_escaped = self._escape_yql_literal(metadata.name)
+                value_escaped = self._escape_yql_literal(metadata.value)
                 metadata_filters.append(
                     f"""
                     (
                         metadata contains sameElement(
-                            name contains '{metadata.name}',
-                            value contains '{metadata.value}'
+                            name contains '{name_escaped}',
+                            value contains '{value_escaped}'
                         )
                     )
                     """
                 )
-                for metadata in self.params.metadata
-            ]
             return f"({' and '.join(metadata_filters)})"
         return None
 

--- a/tests/test_search_adaptors.py
+++ b/tests/test_search_adaptors.py
@@ -347,7 +347,12 @@ async def test_vespa_async_search_adaptor__bad_query_string_still_works(test_ves
 
 @pytest.mark.vespa
 def test_vespa_search_adaptor__apostrophe_in_metadata_still_works(test_vespa):
-    metadata = [{"name": "family.concept_preferred_label", "value":'category/With apostrophe\'s', }]
+    metadata = [
+        {
+            "name": "family.concept_preferred_label",
+            "value": "category/With apostrophe's",
+        }
+    ]
     request = SearchParameters(metadata=metadata)
     try:
         vespa_search(test_vespa, request)
@@ -357,8 +362,15 @@ def test_vespa_search_adaptor__apostrophe_in_metadata_still_works(test_vespa):
 
 @pytest.mark.vespa
 @pytest.mark.asyncio
-async def test_vespa_async_search_adaptor__apostrophe_in_metadata_still_works(test_vespa):
-    metadata = [{"name": "family.concept_preferred_label", "value":'category/With apostrophe\'s', }]
+async def test_vespa_async_search_adaptor__apostrophe_in_metadata_still_works(
+    test_vespa,
+):
+    metadata = [
+        {
+            "name": "family.concept_preferred_label",
+            "value": "category/With apostrophe's",
+        }
+    ]
     request = SearchParameters(metadata=metadata)
     try:
         await async_vespa_search(test_vespa, request)

--- a/tests/test_search_adaptors.py
+++ b/tests/test_search_adaptors.py
@@ -355,6 +355,17 @@ async def test_vespa_async_search_adaptor__bad_query_string_still_works(test_ves
 
 
 @pytest.mark.vespa
+@pytest.mark.asyncio
+async def test_vespa_async_search_adaptor__apostrophe_in_metadata_still_works(test_vespa):
+    metadata = [{"name": "family.concept_preferred_label", "value":'category/With apostrophe\'s', }]
+    request = SearchParameters(metadata=metadata)
+    try:
+        await async_vespa_search(test_vespa, request)
+    except Exception as e:
+        raise AssertionError(f"failed with: {e}")
+
+
+@pytest.mark.vespa
 def test_vespa_search_adaptor__hybrid(test_vespa):
     family_name = "Nationally Determined Contribution: Climate Change Adaptation and Low Emissions Growth Strategy by 2035"
     request = SearchParameters(query_string=family_name)

--- a/tests/test_search_adaptors.py
+++ b/tests/test_search_adaptors.py
@@ -1,6 +1,6 @@
-from timeit import timeit
 import traceback
 from collections.abc import Mapping
+from timeit import timeit
 from typing import Union
 from unittest.mock import patch
 
@@ -333,15 +333,6 @@ def test_vespa_search_adaptor__bad_query_string_still_works(test_vespa):
     except Exception as e:
         raise AssertionError(f"failed with: {e}")
 
-@pytest.mark.vespa
-def test_vespa_search_adaptor__apostrophe_in_metadata_still_works(test_vespa):
-    metadata = [{"name": "family.concept_preferred_label", "value":'category/With apostrophe\'s', }]
-    request = SearchParameters(metadata=metadata)
-    try:
-        vespa_search(test_vespa, request)
-    except Exception as e:
-        raise AssertionError(f"failed with: {e}")
-
 
 @pytest.mark.vespa
 @pytest.mark.asyncio
@@ -350,6 +341,16 @@ async def test_vespa_async_search_adaptor__bad_query_string_still_works(test_ves
     request = SearchParameters(query_string=family_name)
     try:
         await async_vespa_search(test_vespa, request)
+    except Exception as e:
+        raise AssertionError(f"failed with: {e}")
+
+
+@pytest.mark.vespa
+def test_vespa_search_adaptor__apostrophe_in_metadata_still_works(test_vespa):
+    metadata = [{"name": "family.concept_preferred_label", "value":'category/With apostrophe\'s', }]
+    request = SearchParameters(metadata=metadata)
+    try:
+        vespa_search(test_vespa, request)
     except Exception as e:
         raise AssertionError(f"failed with: {e}")
 

--- a/tests/test_search_adaptors.py
+++ b/tests/test_search_adaptors.py
@@ -333,6 +333,15 @@ def test_vespa_search_adaptor__bad_query_string_still_works(test_vespa):
     except Exception as e:
         raise AssertionError(f"failed with: {e}")
 
+@pytest.mark.vespa
+def test_vespa_search_adaptor__apostrophe_in_metadata_still_works(test_vespa):
+    metadata = [{"name": "family.concept_preferred_label", "value":'category/With apostrophe\'s', }]
+    request = SearchParameters(metadata=metadata)
+    try:
+        vespa_search(test_vespa, request)
+    except Exception as e:
+        raise AssertionError(f"failed with: {e}")
+
 
 @pytest.mark.vespa
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description
- escape apostrophes in metadata filters that were causing YQL errors on search


## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Unit tests were added that reproduced the errors we were seeing in the application.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
