### PR TITLE
test: Add more/newer search fixtures

### DIFF
--- a/tests/test_data/search_responses/document_passages.json
+++ b/tests/test_data/search_responses/document_passages.json
@@ -1,0 +1,158 @@
+{
+    "root": {
+        "id": "toplevel",
+        "relevance": 1.0,
+        "fields": {
+            "totalCount": 1
+        },
+        "coverage": {
+            "coverage": 100,
+            "documents": 3421,
+            "full": true,
+            "nodes": 1,
+            "results": 1,
+            "resultsFull": 1
+        },
+        "children": [
+            {
+                "id": "id:doc_search:document_passage::AF.document.009MHNWR.n0007.1020",
+                "relevance": 0.0017429193899782135,
+                "source": "family-document-passage",
+                "fields": {
+                    "sddocname": "document_passage",
+                    "documentid": "id:doc_search:document_passage::AF.document.009MHNWR.n0007.1020",
+                    "text_block_not_stemmed": ":unselected: o Strong working and coordination relationships were built with central level institutions and local level communities and entities. The project allowed for a fairly direct relationship with institutions linked to the water resource management sector, with producers, cooperators, Water Boards, Board of Trustees, City Halls, the academic sector and the National Drought Expert Committee. Nonetheless, evidence on the full and active participation of the private sector was missing.",
+                    "search_weights_ref": "id:doc_search:search_weights::default_weights",
+                    "family_document_ref": "id:doc_search:family_document::AF.document.009MHNWR.n0007",
+                    "text_block_id": "1020",
+                    "text_block_coords": [
+                        [
+                            125.9207992553711,
+                            156.04559326171875
+                        ],
+                        [
+                            540.864013671875,
+                            156.39120483398438
+                        ],
+                        [
+                            540.7703857421875,
+                            269.5032043457031
+                        ],
+                        [
+                            125.82720184326172,
+                            269.1575927734375
+                        ]
+                    ],
+                    "text_block_page": 53,
+                    "text_block_type": "BlockType.TEXT",
+                    "text_block": ":unselected: o Strong working and coordination relationships were built with central level institutions and local level communities and entities. The project allowed for a fairly direct relationship with institutions linked to the water resource management sector, with producers, cooperators, Water Boards, Board of Trustees, City Halls, the academic sector and the National Drought Expert Committee. Nonetheless, evidence on the full and active participation of the private sector was missing.",
+                    "concepts": [
+                        {
+                            "parent_concepts": [
+                                {
+                                    "name": "",
+                                    "id": "Q975"
+                                }
+                            ],
+                            "name": "extreme weather",
+                            "id": "Q374",
+                            "parent_concept_ids_flat": "Q975,",
+                            "model": "KeywordClassifier(\"extreme weather\")",
+                            "end": 383,
+                            "start": 376,
+                            "timestamp": "2025-06-05T13:27:48.345804"
+                        },
+                        {
+                            "parent_concepts": [
+                                {
+                                    "name": "",
+                                    "id": "Q709"
+                                }
+                            ],
+                            "name": "education sector",
+                            "id": "Q774",
+                            "parent_concept_ids_flat": "Q709,",
+                            "model": "KeywordClassifier(\"education sector\")",
+                            "end": 358,
+                            "start": 343,
+                            "timestamp": "2025-06-05T14:54:27.687991"
+                        },
+                        {
+                            "parent_concepts": [
+                                {
+                                    "name": "",
+                                    "id": "Q709"
+                                }
+                            ],
+                            "name": "public sector",
+                            "id": "Q775",
+                            "parent_concept_ids_flat": "Q709,",
+                            "model": "KeywordClassifier(\"public sector\")",
+                            "end": 256,
+                            "start": 231,
+                            "timestamp": "2025-06-05T14:58:04.387175"
+                        },
+                        {
+                            "parent_concepts": [
+                                {
+                                    "name": "",
+                                    "id": "Q709"
+                                }
+                            ],
+                            "name": "water management sector",
+                            "id": "Q818",
+                            "parent_concept_ids_flat": "Q709,",
+                            "model": "KeywordClassifier(\"water management sector\")",
+                            "end": 256,
+                            "start": 231,
+                            "timestamp": "2025-06-05T15:45:24.608990"
+                        }
+                    ],
+                    "spans": [
+                        {
+                            "end": 383,
+                            "start": 376,
+                            "concepts_v2_flat": "nhhzwfva:Q374:mlvecsta",
+                            "concepts_v2": [
+                                {
+                                    "concept_wikibase_id": "Q374",
+                                    "classifier_id": "mlvecsta",
+                                    "concept_id": "nhhzwfva"
+                                }
+                            ]
+                        },
+                        {
+                            "end": 358,
+                            "start": 343,
+                            "concepts_v2_flat": "q5dt2x5y:Q515:lfoyseqb",
+                            "concepts_v2": [
+                                {
+                                    "concept_wikibase_id": "Q515",
+                                    "classifier_id": "lfoyseqb",
+                                    "concept_id": "q5dt2x5y"
+                                }
+                            ]
+                        },
+                        {
+                            "end": 256,
+                            "start": 231,
+                            "concepts_v2_flat": "bqm9freh:Q123:w4v2rzq0,r7nmt2kg:Q456:jue2a08w",
+                            "concepts_v2": [
+                                {
+                                    "concept_wikibase_id": "Q123",
+                                    "classifier_id": "w4v2rzq0",
+                                    "concept_id": "bqm9freh"
+                                },
+                                {
+                                    "concept_wikibase_id": "Q456",
+                                    "classifier_id": "jue2a08w",
+                                    "concept_id": "r7nmt2kg"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}

--- a/tests/test_data/search_responses/family_documents.json
+++ b/tests/test_data/search_responses/family_documents.json
@@ -1,0 +1,292 @@
+{
+  "root": {
+    "id": "toplevel",
+    "relevance": 1.0,
+    "fields": {
+      "totalCount": 1
+    },
+    "coverage": {
+      "coverage": 100,
+      "documents": 4,
+      "full": true,
+      "nodes": 1,
+      "results": 1,
+      "resultsFull": 1
+    },
+    "children": [
+      {
+        "id": "id:doc_search:family_document::AF.document.009MHNWR.n0007",
+        "relevance": 0.0017429193899782135,
+        "source": "family-document-passage",
+        "fields": {
+          "sddocname": "family_document",
+          "documentid": "id:doc_search:family_document::AF.document.009MHNWR.n0007",
+          "search_weights_ref": "id:doc_search:search_weights::default_weights",
+          "family_name": "Addressing Climate Change Risks on Water Resources in Honduras: Increased Systemic Resilience and Reduced Vulnerability of the Urban Poor",
+          "family_description": "The objective of the project is to increase resilience to climate change and water-related risks for the most vulnerable population in Honduras through pilot activities and an overarching intervention to mainstream climate change considerations into water sector policies. The specific project objectives included: Strengthen institutional structures to mainstream climate risks into water resources management, national planning; Assist in safeguarding water supplies of Tegucigalpa metro area against water scarcity and extreme climate events; Build capacity and outreach to enable all stakeholders to respond to long-term climate change impacts",
+          "family_import_id": "AF.family.009MHNWR.0",
+          "family_slug": "addressing-climate-change-risks-on-water-resources-in-honduras-increased-systemic-resilience-and-reduced-vulnerability-of-the-urban-poor_df09",
+          "family_publication_ts": "2010-09-17T00:00:00+00:00",
+          "family_category": "MCF",
+          "family_geography": "HND",
+          "family_geographies": [
+            "HND"
+          ],
+          "family_source": "AF",
+          "document_import_id": "AF.document.009MHNWR.n0007",
+          "document_title": "Final evaluation report",
+          "document_slug": "final-evaluation-report_8dec",
+          "document_languages": [
+            "English"
+          ],
+          "document_md5_sum": "0996c52e8a82f6caf973962e8972797c",
+          "document_content_type": "application/pdf",
+          "document_cdn_object": "HND/2010/addressing-climate-change-risks-on-water-resources-in-honduras-increased-systemic-resilience-and-reduced-vulnerability-of-the-urban-poor_0996c52e8a82f6caf973962e8972797c.pdf",
+          "document_source_url": "https://fifspubprd.azureedge.net/afdocuments/project/62/4399_AF_Honduras_Terminal%20eval%20report_May%2017.pdf",
+          "corpus_import_id": "MCF.corpus.AF.n0000",
+          "corpus_type_name": "AF",
+          "metadata": [
+            {
+              "name": "family.region",
+              "value": "Latin America & Caribbean"
+            },
+            {
+              "name": "family.sector",
+              "value": "Water management"
+            },
+            {
+              "name": "family.status",
+              "value": "Project Completed"
+            },
+            {
+              "name": "family.project_id",
+              "value": "009MHNWR"
+            },
+            {
+              "name": "family.project_url",
+              "value": "https://www.adaptation-fund.org/project/addressing-climate-change-risks-on-water-resources-in-honduras-increased-systemic-resilience-and-reduced-vulnerability-of-the-urban-poor/"
+            },
+            {
+              "name": "family.implementing_agency",
+              "value": "UN Development Programme"
+            },
+            {
+              "name": "family.project_value_fund_spend",
+              "value": "5620300"
+            },
+            {
+              "name": "family.project_value_co_financing",
+              "value": "0"
+            }
+          ],
+          "concept_counts": {
+            "Q765:trade sector": 2,
+            "Q404:terrestrial risk": 14,
+            "Q715:tax": 2,
+            "Q684:indigenous people": 1,
+            "Q676:marginalized ethnicity": 1,
+            "Q1286:early warning system": 3,
+            "Q1343:climate finance": 21,
+            "Q788:fishing sector": 1,
+            "Q1276:direct investment": 2,
+            "Q856:healthcare sector": 4,
+            "Q779:finance and insurance sector": 9,
+            "Q762:energy supply sector": 1,
+            "Q760:extractive sector": 6,
+            "Q787:forestry sector": 4,
+            "Q763:environmental management sector": 5,
+            "Q1167:people with limited assets": 9,
+            "Q973:slow onset event": 1,
+            "Q701:people on the move": 1,
+            "Q786:agriculture sector": 9,
+            "Q764:construction sector": 6,
+            "Q818:water management sector": 30,
+            "Q1277:fees and charges": 1,
+            "Q1362:climate fund": 21,
+            "Q956:societal impact": 12,
+            "Q769:information communication technology sector": 3,
+            "Q1282:zoning and spatial planning": 11,
+            "Q695:youth": 2,
+            "Q704:women and minority genders": 14,
+            "Q1281:codes and standards": 1,
+            "Q775:public sector": 23,
+            "Q374:extreme weather": 19,
+            "Q774:education sector": 3,
+            "Q986:geohazard": 4
+          },
+          "concepts_v2": [
+            {
+              "count": 9,
+              "classifier_id": "z664n8h8",
+              "concept_id": "b836x3e3"
+            },
+            {
+              "count": 2,
+              "classifier_id": "3k993hvh",
+              "concept_id": "b836x3e3"
+            },
+            {
+              "count": 1,
+              "classifier_id": "t9kpjjab",
+              "concept_id": "mbu7hjcq"
+            },
+            {
+              "count": 1,
+              "classifier_id": "zjmxvf2p",
+              "concept_id": "3j4qadvf"
+            },
+            {
+              "count": 1,
+              "classifier_id": "anfhdhxm",
+              "concept_id": "2gvuuvnw",
+              "concept_wikibase_id": "Q789"
+            },
+            {
+              "count": 3,
+              "classifier_id": "6vyhx47j",
+              "concept_id": "mtg8hg7x"
+            },
+            {
+              "count": 1,
+              "classifier_id": "nd9bzgv5",
+              "concept_id": "rns7bps4"
+            },
+            {
+              "count": 1,
+              "classifier_id": "gjx26rb3",
+              "concept_id": "awgxsauj"
+            },
+            {
+              "count": 9,
+              "classifier_id": "4xdbmh5t",
+              "concept_id": "nhhzwfva",
+              "concept_wikibase_id": "Q374"
+            },
+            {
+              "count": 4,
+              "classifier_id": "28zh5bs4",
+              "concept_id": "xaqt5dpj"
+            },
+            {
+              "count": 1,
+              "classifier_id": "3snuveg6",
+              "concept_id": "ca7awjjg"
+            },
+            {
+              "count": 1,
+              "classifier_id": "46rgzfnu",
+              "concept_id": "egnxgkd8"
+            },
+            {
+              "count": 2,
+              "classifier_id": "fqez4pu2",
+              "concept_id": "bahk6avj"
+            },
+            {
+              "count": 1,
+              "classifier_id": "3ehtcmgr",
+              "concept_id": "9tskhyxb"
+            },
+            {
+              "count": 4,
+              "classifier_id": "zqmpxwvx",
+              "concept_id": "jr3s4jsa"
+            },
+            {
+              "count": 2,
+              "classifier_id": "f5597c7c",
+              "concept_id": "w7s2zf4v"
+            },
+            {
+              "count": 6,
+              "classifier_id": "hr5fnv8a",
+              "concept_id": "zhj5vezx"
+            },
+            {
+              "count": 1,
+              "classifier_id": "b9htgybc",
+              "concept_id": "ah84cx9r"
+            },
+            {
+              "count": 5,
+              "classifier_id": "aukd7tza",
+              "concept_id": "3nj2mmps"
+            },
+            {
+              "count": 6,
+              "classifier_id": "6anbektb",
+              "concept_id": "3h6q3tmx"
+            },
+            {
+              "count": 2,
+              "classifier_id": "y8t4ztbx",
+              "concept_id": "9nzh8ngn"
+            },
+            {
+              "count": 3,
+              "classifier_id": "3dhbaxdc",
+              "concept_id": "rfrb6hue"
+            },
+            {
+              "count": 3,
+              "classifier_id": "jd5bafz5",
+              "concept_id": "q5dt2x5y"
+            },
+            {
+              "count": 3,
+              "classifier_id": "arevhgbf",
+              "concept_id": "bqm9freh"
+            },
+            {
+              "count": 9,
+              "classifier_id": "cqt336zm",
+              "concept_id": "8gpdnspp"
+            },
+            {
+              "count": 9,
+              "classifier_id": "a2u6z83b",
+              "concept_id": "kynzgerh"
+            },
+            {
+              "count": 4,
+              "classifier_id": "ukwxdeh3",
+              "concept_id": "tntx3gy5"
+            },
+            {
+              "count": 1,
+              "classifier_id": "z6txkdwk",
+              "concept_id": "xzknej96"
+            },
+            {
+              "count": 0,
+              "classifier_id": "ebvzbghd",
+              "concept_id": "r7nmt2kg"
+            },
+            {
+              "count": 4,
+              "classifier_id": "h5n4vrvw",
+              "concept_id": "w3wrtq64"
+            },
+            {
+              "count": 2,
+              "classifier_id": "q2b4mq7k",
+              "concept_id": "dw5brr9c"
+            },
+            {
+              "count": 1,
+              "classifier_id": "d2gk7ksc",
+              "concept_id": "w9z6qa9t"
+            },
+            {
+              "count": 4,
+              "classifier_id": "fz3ejy99",
+              "concept_id": "gmerqh8z"
+            }
+          ],
+          "family_name_index": "Addressing Climate Change Risks on Water Resources in Honduras: Increased Systemic Resilience and Reduced Vulnerability of the Urban Poor",
+          "family_description_index": "The objective of the project is to increase resilience to climate change and water-related risks for the most vulnerable population in Honduras through pilot activities and an overarching intervention to mainstream climate change considerations into water sector policies. The specific project objectives included: Strengthen institutional structures to mainstream climate risks into water resources management, national planning; Assist in safeguarding water supplies of Tegucigalpa metro area against water scarcity and extreme climate events; Build capacity and outreach to enable all stakeholders to respond to long-term climate change impacts"
+        }
+      }
+    ]
+  }
+}

--- a/tests/test_search_adaptors.py
+++ b/tests/test_search_adaptors.py
@@ -1,3 +1,4 @@
+
 import traceback
 from collections.abc import Mapping
 from timeit import timeit
@@ -11,6 +12,19 @@ from cpr_sdk.models.search import (
     ConceptFilter,
     ConceptV2DocumentFilter,
     ConceptV2PassageFilter,
+    Document,
+    Filters,
+    Hit,
+    MetadataFilter,
+    OperandTypeEnum,
+    Passage,
+    SearchParameters,
+    SearchResponse,
+    sort_fields,
+)
+from cpr_sdk.models.search import (
+    ConceptCountFilter,
+    ConceptFilter,
     Document,
     Filters,
     Hit,

--- a/tests/test_search_responses.py
+++ b/tests/test_search_responses.py
@@ -1,11 +1,10 @@
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 
 import pytest
 from cpr_sdk.exceptions import FetchError
-from cpr_sdk.models.search import Hit
+from cpr_sdk.models.search import Document, Hit, Passage
 from cpr_sdk.vespa import parse_vespa_response, split_document_id
-from cpr_sdk.models.search import Passage
 from vespa.io import VespaResponse
 
 
@@ -70,6 +69,165 @@ def test_whether_continuation_token_is_returned_when_present(
 
 def test_whether_valid_get_document_response_is_parsed(valid_get_document_response):
     assert Hit.from_vespa_response(valid_get_document_response)
+
+
+def test_whether_valid_get_document_response_is_parsed_hit():
+    path = "tests/test_data/search_responses/family_documents.json"
+    with open(path) as f:
+        response_json = json.load(f)
+
+    assert Document(
+        family_name="Addressing Climate Change Risks on Water Resources in Honduras: Increased Systemic Resilience and Reduced Vulnerability of the Urban Poor",
+        family_description="The objective of the project is to increase resilience to climate change and water-related risks for the most vulnerable population in Honduras through pilot activities and an overarching intervention to mainstream climate change considerations into water sector policies. The specific project objectives included: Strengthen institutional structures to mainstream climate risks into water resources management, national planning; Assist in safeguarding water supplies of Tegucigalpa metro area against water scarcity and extreme climate events; Build capacity and outreach to enable all stakeholders to respond to long-term climate change impacts",
+        family_source="AF",
+        family_import_id="AF.family.009MHNWR.0",
+        family_slug="addressing-climate-change-risks-on-water-resources-in-honduras-increased-systemic-resilience-and-reduced-vulnerability-of-the-urban-poor_df09",
+        family_category="MCF",
+        family_publication_ts=datetime(2010, 9, 17, 0, 0, tzinfo=timezone.utc),
+        family_geography="HND",
+        family_geographies=["HND"],
+        document_import_id="AF.document.009MHNWR.n0007",
+        document_slug="final-evaluation-report_8dec",
+        document_languages=["English"],
+        document_content_type="application/pdf",
+        document_cdn_object="HND/2010/addressing-climate-change-risks-on-water-resources-in-honduras-increased-systemic-resilience-and-reduced-vulnerability-of-the-urban-poor_0996c52e8a82f6caf973962e8972797c.pdf",
+        document_source_url="https://fifspubprd.azureedge.net/afdocuments/project/62/4399_AF_Honduras_Terminal%20eval%20report_May%2017.pdf",
+        document_title="Final evaluation report",
+        corpus_type_name="AF",
+        corpus_import_id="MCF.corpus.AF.n0000",
+        metadata=[
+            {"name": "family.region", "value": "Latin America & Caribbean"},
+            {"name": "family.sector", "value": "Water management"},
+            {"name": "family.status", "value": "Project Completed"},
+            {"name": "family.project_id", "value": "009MHNWR"},
+            {
+                "name": "family.project_url",
+                "value": "https://www.adaptation-fund.org/project/addressing-climate-change-risks-on-water-resources-in-honduras-increased-systemic-resilience-and-reduced-vulnerability-of-the-urban-poor/",
+            },
+            {"name": "family.implementing_agency", "value": "UN Development Programme"},
+            {"name": "family.project_value_fund_spend", "value": "5620300"},
+            {"name": "family.project_value_co_financing", "value": "0"},
+        ],
+        relevance=0.0017429193899782135,
+        rank_features=None,
+        concept_counts={
+            "Q765:trade sector": 2,
+            "Q404:terrestrial risk": 14,
+            "Q715:tax": 2,
+            "Q684:indigenous people": 1,
+            "Q676:marginalized ethnicity": 1,
+            "Q1286:early warning system": 3,
+            "Q1343:climate finance": 21,
+            "Q788:fishing sector": 1,
+            "Q1276:direct investment": 2,
+            "Q856:healthcare sector": 4,
+            "Q779:finance and insurance sector": 9,
+            "Q762:energy supply sector": 1,
+            "Q760:extractive sector": 6,
+            "Q787:forestry sector": 4,
+            "Q763:environmental management sector": 5,
+            "Q1167:people with limited assets": 9,
+            "Q973:slow onset event": 1,
+            "Q701:people on the move": 1,
+            "Q786:agriculture sector": 9,
+            "Q764:construction sector": 6,
+            "Q818:water management sector": 30,
+            "Q1277:fees and charges": 1,
+            "Q1362:climate fund": 21,
+            "Q956:societal impact": 12,
+            "Q769:information communication technology sector": 3,
+            "Q1282:zoning and spatial planning": 11,
+            "Q695:youth": 2,
+            "Q704:women and minority genders": 14,
+            "Q1281:codes and standards": 1,
+            "Q775:public sector": 23,
+            "Q374:extreme weather": 19,
+            "Q774:education sector": 3,
+            "Q986:geohazard": 4,
+        },
+    ) == Hit.from_vespa_response(response_json["root"]["children"][0])
+
+
+def test_whether_valid_get_passage_response_is_parsed_hit():
+    path = "tests/test_data/search_responses/document_passages.json"
+    with open(path) as f:
+        response_json = json.load(f)
+
+    assert Passage(
+        family_name=None,
+        family_description=None,
+        family_source=None,
+        family_import_id=None,
+        family_slug=None,
+        family_category=None,
+        family_publication_ts=None,
+        family_geography=None,
+        family_geographies=[],
+        document_import_id=None,
+        document_slug=None,
+        document_languages=[],
+        document_content_type=None,
+        document_cdn_object=None,
+        document_source_url=None,
+        document_title=None,
+        corpus_type_name=None,
+        corpus_import_id=None,
+        metadata=None,
+        relevance=0.0017429193899782135,
+        rank_features=None,
+        text_block=":unselected: o Strong working and coordination relationships were built with central level institutions and local level communities and entities. The project allowed for a fairly direct relationship with institutions linked to the water resource management sector, with producers, cooperators, Water Boards, Board of Trustees, City Halls, the academic sector and the National Drought Expert Committee. Nonetheless, evidence on the full and active participation of the private sector was missing.",
+        text_block_id="1020",
+        text_block_type="BlockType.TEXT",
+        text_block_page=53,
+        text_block_coords=[
+            (125.9207992553711, 156.04559326171875),
+            (540.864013671875, 156.39120483398438),
+            (540.7703857421875, 269.5032043457031),
+            (125.82720184326172, 269.1575927734375),
+        ],
+        concepts=[
+            Passage.Concept(
+                id="Q374",
+                name="extreme weather",
+                parent_concepts=[{"name": "", "id": "Q975"}],
+                parent_concept_ids_flat="Q975,",
+                model='KeywordClassifier("extreme weather")',
+                end=383,
+                start=376,
+                timestamp=datetime(2025, 6, 5, 13, 27, 48, 345804),
+            ),
+            Passage.Concept(
+                id="Q774",
+                name="education sector",
+                parent_concepts=[{"name": "", "id": "Q709"}],
+                parent_concept_ids_flat="Q709,",
+                model='KeywordClassifier("education sector")',
+                end=358,
+                start=343,
+                timestamp=datetime(2025, 6, 5, 14, 54, 27, 687991),
+            ),
+            Passage.Concept(
+                id="Q775",
+                name="public sector",
+                parent_concepts=[{"name": "", "id": "Q709"}],
+                parent_concept_ids_flat="Q709,",
+                model='KeywordClassifier("public sector")',
+                end=256,
+                start=231,
+                timestamp=datetime(2025, 6, 5, 14, 58, 4, 387175),
+            ),
+            Passage.Concept(
+                id="Q818",
+                name="water management sector",
+                parent_concepts=[{"name": "", "id": "Q709"}],
+                parent_concept_ids_flat="Q709,",
+                model='KeywordClassifier("water management sector")',
+                end=256,
+                start=231,
+                timestamp=datetime(2025, 6, 5, 15, 45, 24, 608990),
+            ),
+        ],
+    ) == Hit.from_vespa_response(response_json["root"]["children"][0])
 
 
 def test_whether_valid_get_passage_response_is_parsed(valid_get_passage_response):

--- a/tests/test_search_responses.py
+++ b/tests/test_search_responses.py
@@ -5,7 +5,6 @@ import pytest
 from cpr_sdk.exceptions import FetchError
 from cpr_sdk.models.search import Document, Hit, Passage
 from cpr_sdk.vespa import parse_vespa_response, split_document_id
-from vespa.io import VespaResponse
 
 
 @pytest.fixture


### PR DESCRIPTION
# Description

These were gotten from doing some Vespa queries. The other tests use data that is for feeding. They're very similar.

**Tests**

_Local_

I created a quick script to confirm this works:

```
from cpr_sdk.search_adaptors import VespaSearchAdapter
from cpr_sdk.models.search import Document, Passage, SearchParameters


def main():
    vespa_adapter = VespaSearchAdapter(
        instance_url="http://localhost:8080",
        skip_cert_usage=True,
    )

    # Example 1: Query for a document by ID
    print("1. Fetching a document by ID...")
    try:
        # Document ID from staged test data
        document_id = "id:doc_search:family_document::AF.document.009MHNWR.n0007"

        print(f"Fetching document: {document_id}")
        document: Document = vespa_adapter.get_by_id(document_id)

        print(f"✓ Document found:")
        print(f"  Concepts' Counts: {document.concept_counts}")

    except Exception as e:
        print(f"✗ Error fetching document: {e}")

    print("\n" + "=" * 60 + "\n")

    # Example 2: Query for a passage by ID
    print("2. Fetching a passage by ID...")
    try:
        # Passage ID from staged test data
        passage_id = "id:doc_search:document_passage::AF.document.009MHNWR.n0007.1020"

        print(f"Fetching passage: {passage_id}")
        passage: Passage = vespa_adapter.get_by_id(passage_id)

        print(f"✓ Passage found:")
        if passage.concepts:
            print(f"  Concepts found: {len(passage.concepts)}")
            for i, concept in enumerate(passage.concepts[:3]):  # Show first 3
                print(f"    - {concept.name} (ID: {concept.id})")

    except Exception as e:
        print(f"✗ Error fetching passage: {e}")


if __name__ == "__main__":
    main()
```

It works both before, and after, the nesting change.

```
$ poetry run python vespa_search_example.py
1. Fetching a document by ID...
Fetching document: id:doc_search:family_document::AF.document.009MHNWR.n0007
Using http Authentication against endpoint http://localhost:8080/ApplicationStatus
✓ Document found:
  Concepts' Counts: {'Q765:trade sector': 2, 'Q404:terrestrial risk': 14, 'Q715:tax': 2, 'Q684:indigenous people': 1, 'Q676:marginalized ethnicity': 1, 'Q1286:early warning system': 3, 'Q1343:climate finance': 21, 'Q788:fishing sector': 1, 'Q1276:direct investment': 2, 'Q856:healthcare sector': 4, 'Q779:finance and insurance sector': 9, 'Q762:energy supply sector': 1, 'Q760:extractive sector': 6, 'Q787:forestry sector': 4, 'Q763:environmental management sector': 5, 'Q1167:people with limited assets': 9, 'Q973:slow onset event': 1, 'Q701:people on the move': 1, 'Q786:agriculture sector': 9, 'Q764:construction sector': 6, 'Q818:water management sector': 30, 'Q1277:fees and charges': 1, 'Q1362:climate fund': 21, 'Q956:societal impact': 12, 'Q769:information communication technology sector': 3, 'Q1282:zoning and spatial planning': 11, 'Q695:youth': 2, 'Q704:women and minority genders': 14, 'Q1281:codes and standards': 1, 'Q775:public sector': 23, 'Q374:extreme weather': 19, 'Q774:education sector': 3, 'Q986:geohazard': 4}

============================================================

2. Fetching a passage by ID...
Fetching passage: id:doc_search:document_passage::AF.document.009MHNWR.n0007.1020
✓ Passage found:
  Concepts found: 4
    - extreme weather (ID: Q374)
    - education sector (ID: Q774)
    - public sector (ID: Q775)
```

_Production_

```
import os
from cpr_sdk.search_adaptors import VespaSearchAdapter
from cpr_sdk.models.search import (
    Document,
    Passage,
    SearchParameters,
    ConceptCountFilter,
    OperandTypeEnum,
)


def main():
    vespa_adapter = VespaSearchAdapter(
        instance_url="...",
        cert_directory=os.path.expanduser(
            "~/...
        ),
    )

    # Example 1: Search for passages with concepts
    print("1. Searching for passages with concepts...")

    # Search for passages that have concepts
    from cpr_sdk.models.search import ConceptFilter

    response = vespa_adapter.search(
        SearchParameters(
            concept_filters=[ConceptFilter(name="name", value="public sector")],
            documents_only=False,
            limit=3,
        )
    )

    print(f"✓ Found passages with concepts:")
    print(f"  Total families: {response.total_family_hits}")

    for i, family in enumerate(response.families):
        print(f"\n  Family {i+1}: {family.id}")
        for j, hit in enumerate(family.hits[:3]):  # Show first 3 hits
            print(f"    Hit {j+1}: {type(hit).__name__}")
            if isinstance(hit, Passage):
                print(f"      Text Block ID: {hit.text_block_id}")
                print(f"      Text: {hit.text_block[:150]}...")
                if hasattr(hit, "concepts") and hit.concepts:
                    print(f"      Concepts: {len(hit.concepts)}")
                    for concept in hit.concepts[:3]:
                        print(f"        - {concept.name} (ID: {concept.id})")
            elif isinstance(hit, Document):
                print(f"      Document: {hit.document_import_id}")
                print(f"      Title: {hit.document_title}")
                if hasattr(hit, "concept_counts") and hit.concept_counts:
                    total_concepts = sum(hit.concept_counts.values())
                    print(f"      Total concept mentions: {total_concepts}")


if __name__ == "__main__":
    main()

```

It works after the nesting change:

```
poetry run python vespa_search_example.py
1. Searching for passages with concepts...
Using mtls_key_cert Authentication against endpoint ...
✓ Found passages with concepts:
  Total families: 7918

  Family 1: CCLW.family.i00000698.n0000
    Hit 1: Passage
      Text Block ID: 7165
      Text: in the water management sector. The previous version of the Water Law Act provided for the functioning of the President of the National Water Manageme...
      Concepts: 28
        - public sector (ID: Q775)
        - public sector (ID: Q775)
        - public sector (ID: Q775)
    Hit 2: Passage
      Text Block ID: 7166
      Text: Of particular concern were numerous problems in the investment process in water management. The nature of investments in water management, which large...
      Concepts: 14
        - public sector (ID: Q775)
        - public sector (ID: Q775)
        - public sector (ID: Q775)
    Hit 3: Passage
      Text Block ID: 6225
      Text: The State Purchasing Policy - one of the strategic projects of the Strategy for Responsible Development - is also intended to support green public pro...
      Concepts: 9
        - construction sector (ID: Q764)
        - public sector (ID: Q775)
        - public sector (ID: Q775)

  Family 2: CCLW.family.i00003913.n0000
    Hit 1: Passage
      Text Block ID: 5059
      Text: - introduction of the possibility of ex-ante control of dossiers prior to publication by the contracting authority Pursuant to the Public Procurement ...
      Concepts: 14
        - public sector (ID: Q775)
        - public sector (ID: Q775)
        - public sector (ID: Q775)
    Hit 2: Passage
      Text Block ID: 5077
      Text: planned public procurement; b) provide personal consultations on a partial issue in public procurement; c) prepare an opinion on the compliance of par...
      Concepts: 10
        - public sector (ID: Q775)
        - public sector (ID: Q775)
        - public sector (ID: Q775)
    Hit 3: Passage
      Text Block ID: 5392
      Text: and increase their effectiveness. Slovak authorities will prepare a national strategy for the timely and efficient transition to end-to-end e-procurem...
      Concepts: 10
        - public sector (ID: Q775)
        - public sector (ID: Q775)
        - public sector (ID: Q775)

  Family 3: CCLW.family.8982.0
    Hit 1: Passage
      Text Block ID: 61
      Text: that public procurement be used as an instrument to implement both European and national policies on social, environmental, innovation and development...
      Concepts: 16
        - greenhouse gas (ID: Q218)
        - greenhouse gas (ID: Q218)
        - carbon dioxide (ID: Q223)
    Hit 2: Passage
      Text Block ID: 54
      Text: In these organizations, public procurement is recognized as having an important potential to facilitate changes in those production and consumption mo...
      Concepts: 11
        - trade sector (ID: Q765)
        - public sector (ID: Q775)
        - public sector (ID: Q775)
    Hit 3: Passage
      Text Block ID: 107
      Text: The functions referred to in sections b) and c) will be carried out in collaboration with the State Public Procurement Advisory Board, and in coherenc...
      Concepts: 2
        - public sector (ID: Q775)
        - public sector (ID: Q775)
```

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated
  soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->

- [ ] I've read and followed all steps in the
      [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
      section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax
      described in the
      [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings)
      section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my
      new functionality.
