### PR TITLE
add failing semantic search test for CCC

### DIFF
--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
 _MINOR = "24"
-_PATCH = "0"
+_PATCH = "1"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)

--- a/tests/search_intentions/test_field_characteristics.py
+++ b/tests/search_intentions/test_field_characteristics.py
@@ -140,6 +140,16 @@ test_cases = [
         all_or_any="all",
         known_failure=True,
     ),
+    FieldCharacteristicsTestCase(
+        search_terms="statement",
+        test_field="text_block_text",
+        exact_match=False,
+        characteristics_test=(lambda x: x not in {"plum"}),
+        description="Semantic search should not return obviously irrelevant passages",
+        k=100,
+        document_id="Sabin.document.18746.18749",
+        known_failure=True,
+    ),
 ]
 
 


### PR DESCRIPTION
# Description

Adds a failing search test – see [APP-1118](https://linear.app/climate-policy-radar/issue/APP-1118/related-phrases-for-foreign-documents-return-really-weird-results#comment-c984eb3c)
## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [X] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
