### PR TITLE
fix(search): Correct field name

### DIFF
--- a/src/cpr_sdk/models/search.py
+++ b/src/cpr_sdk/models/search.py
@@ -1074,7 +1074,7 @@ class Concept(BaseModel):
     related_concepts: Sequence[str] = Field(
         default_factory=list, description="List of related concept IDs"
     )
-    recursive_concept_of: Sequence[str] | None = Field(
+    recursive_subconcept_of: Sequence[str] | None = Field(
         default=None,
         description="List of all parent concept IDs, recursively up the hierarchy",
     )

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "4"
 _MINOR = "0"
-_PATCH = "0"
+_PATCH = "1"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)

--- a/tests/test_search_responses.py
+++ b/tests/test_search_responses.py
@@ -1077,7 +1077,7 @@ def test_parse_get_concept_response():
             subconcept_of=["njhxa72q"],
             has_subconcept=[],
             related_concepts=[],
-            recursive_concept_of=None,
+            recursive_subconcept_of=None,
             recursive_has_subconcept=None,
             response_raw={
                 "pathId": "/document/v1/doc_search/concept/docid/Q730.hzaw3hdg",
@@ -1118,7 +1118,7 @@ def test_parse_query_concept_response():
             subconcept_of=["njhxa72q"],
             has_subconcept=[],
             related_concepts=[],
-            recursive_concept_of=None,
+            recursive_subconcept_of=None,
             recursive_has_subconcept=None,
             response_raw={
                 "id": "id:doc_search:concept::Q730.hzaw3hdg",


### PR DESCRIPTION
# Description

As in the schema[^1] and model[^2]. Using _patch_ since no one else is using this yet.

FIXES PLA-849

[^1]: https://github.com/climatepolicyradar/navigator-infra/blob/ce18e074d4523865dbd9d6dc2d2beb94340e6b53/vespa/navigator_app_dev/schemas/concept.sd#L50-L52
[^2]: https://github.com/climatepolicyradar/knowledge-graph/blob/dd7ffa0232a3743a9b22a4eee5fbf83ea7e64b9f/knowledge_graph/concept.py#L70-L73

## Proposed version

Please select the option below that is most relevant from the list below. This will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make sure your selected option is marked `[x]` with no spaces in between the brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

Relied on existing tests.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
