### PR TITLE
Adding optional existing document ids field to enable stats creation from PipelineUpdates

### DIFF
--- a/src/cpr_sdk/pipeline_general_models.py
+++ b/src/cpr_sdk/pipeline_general_models.py
@@ -120,6 +120,7 @@ class PipelineUpdates(BaseModel):
 
     new_documents: List[BackendDocument]
     updated_documents: dict[str, List[Update]]
+    existing_document_ids: List[str] | None = None
 
 
 class ExecutionData(BaseModel):

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "4"
-_MINOR = "0"
-_PATCH = "1"
+_MINOR = "1"
+_PATCH = "0"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)


### PR DESCRIPTION
# Description

Adding optional existing document ids field to enable stats creation from PipelineUpdates. As part of [this](https://linear.app/climate-policy-radar/issue/PLA-951/refactor-identify-updates-enable-stats-creation-from-pipelineupdates) ticket.

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [] Patch
- [X] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [X] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [X] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [X] If this PR fixes a bug, I've added a test that will fail without my fix.
- [X] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
