### PR TITLE
Feature/pla 1125 support for placeholder documents  sdk update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,17 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v6
 
+      - name: Remove unused software
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: true
+
       - name: Install poetry
         run: pipx install poetry
 

--- a/src/cpr_sdk/pipeline_general_models.py
+++ b/src/cpr_sdk/pipeline_general_models.py
@@ -92,6 +92,7 @@ class UpdateTypes(str, Enum):
             reprocessing but not redownload from source.
         REPROCESS (str): Indicates that the document should be reprocessed, including
             redownload from source and reparse.
+        NO_DATA (str): Indicates that the document has no physical document (e.g. pdf).
     """
 
     NAME = "name"
@@ -101,6 +102,7 @@ class UpdateTypes(str, Enum):
     METADATA = "metadata"
     REPARSE = "reparse"
     REPROCESS = "reprocess"
+    NO_DATA = "no_data"
 
 
 class Update(BaseModel):

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "4"
 _MINOR = "2"
-_PATCH = "1"
+_PATCH = "2"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)


### PR DESCRIPTION
# Description

This update adds a new UpdateType to be utilised within the document processing pipeline. Signalling a document update to no data. This reflects a document with no associated physical document (pdf). 

Note: I had to add software clean up because the job was failing with `no space left on device`. 

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [X] Minor version
- [ ] Major version

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

## How Has This Been Tested?

Unit tests. 

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
