### PR TITLE
Feature: Removing pipeline objects that are deprecated or migrated.

### DIFF
--- a/src/cpr_sdk/pipeline_general_models.py
+++ b/src/cpr_sdk/pipeline_general_models.py
@@ -1,6 +1,5 @@
 from datetime import datetime
-from enum import Enum
-from typing import Any, List, Mapping, Optional, Sequence, Union
+from typing import Any, Mapping, Optional, Sequence
 
 from pydantic import BaseModel, field_validator
 
@@ -65,65 +64,3 @@ class InputData(BaseModel):
     """Expected input data containing RDS state."""
 
     documents: Mapping[str, BackendDocument]
-
-
-class UpdateTypes(str, Enum):
-    """
-    UpdateTypes that are recognised and have resulting actions in the pipeline.
-
-    A mapping of the update type to the action can be found in the ingest repo:
-    https://github.com/climatepolicyradar/navigator-data-ingest/blob/main/src/
-    navigator_data_ingest/base/updated_document_actions.py#L490
-
-    Attributes:
-        NAME (str): Represents the name of the document, causes embeddings generation to
-            be re-triggered for a document.
-        DESCRIPTION (str): Represents the description of the document, causes embeddings
-            generation to be re-triggered for a document.
-        SLUG (str): Represents the slug (a URL-friendly version of the name) of the
-            document, triggers an update of the field in the relating s3 objects such
-            that the new data is reflected in vespa.
-        SOURCE_URL (str): Represents the source URL of the document and triggers full
-            reprocessing and download from source of the document.
-        METADATA (str): Represents the metadata associated with the document and
-            indicates that the metadata of the objects in s3 relating to the document
-            should be updated.
-        REPARSE (str): Indicates that the document should be reparsed, including full
-            reprocessing but not redownload from source.
-        REPROCESS (str): Indicates that the document should be reprocessed, including
-            redownload from source and reparse.
-    """
-
-    NAME = "name"
-    DESCRIPTION = "description"
-    SLUG = "slug"
-    SOURCE_URL = "source_url"
-    METADATA = "metadata"
-    REPARSE = "reparse"
-    REPROCESS = "reprocess"
-
-
-class Update(BaseModel):
-    """Results of comparing db state data against the s3 data to identify updates."""
-
-    s3_value: Optional[Union[str, datetime, dict]] = None
-    db_value: Optional[Union[str, datetime, dict]] = None
-    type: UpdateTypes
-
-
-class PipelineUpdates(BaseModel):
-    """
-    Expected input data containing document updates and new documents.
-
-    This is utilized by the ingest stage of the pipeline.
-    """
-
-    new_documents: List[BackendDocument]
-    updated_documents: dict[str, List[Update]]
-    existing_document_ids: List[str] | None = None
-
-
-class ExecutionData(BaseModel):
-    """Data unique to a step functions execution that is required at later stages."""
-
-    input_dir_path: str

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "4"
 _MINOR = "2"
-_PATCH = "1"
+_PATCH = "2"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)


### PR DESCRIPTION
# Description

These objects are now only utilised in the navigator-data-pipeline repo or have been deprecated and thus removing from this sdk. 

- UpdateTypes is deprecated.
- PipelineUpdates and Update objects have been migrated to the pipeline repo. 
- ExecutionData is unused. 

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [x] Patch
- [ ] Minor version
- [ ] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
