### PR TITLE
Feature/pla 1384 deprecate embeddings from vespa query layer

### DIFF
--- a/docs/search/2_cpr_searches.md
+++ b/docs/search/2_cpr_searches.md
@@ -122,11 +122,53 @@ Explainers of specific search types follow, from lowest to highest complexity.
 > [!WARNING]
 > In the following sections, example YQL queries and rank profiles are used to explain the mechanics of each search. **These will not necessarily be the same as are in product by the time you read this!** These are more meant as practical ways to explain relevant mechanics of Vespa and our searches.
 
+## Default text search
+
+Default text search is the default search on our tool. It uses Vespa's `userInput` operator to turn a free text query into the most suitable lower-level query, ranked by BM25.
+
+### Annotated YQL
+
+In the retrieval part, [userInput](https://docs.vespa.ai/en/reference/query-language-reference.html#userinput) turns the query string into the lower-level query Vespa thinks is most suitable. It operates on the *default fieldset* defined in each schema.
+
+``` sql
+select * from sources family_document, document_passage where (
+    (userInput(@query_string))
+)
+limit 0
+| all(
+    group(family_import_id)
+    output(count()) max(20)
+    each( output(count()) max(10) each( output( summary(search_summary) ) ) )
+)
+```
+
+### Relevant schema parts for default search
+
+No explicit rank profile is set for default text search, so Vespa uses its built-in `default` profile which applies BM25 ranking over the default fieldset for each schema.
+
+[BM25](https://en.wikipedia.org/wiki/Okapi_BM25) ranks according to the number of times a term in the query appears in each record, penalising occurrences (like 'climate') which appear in lots of records compared to those that are rarer.
+
+The default fieldsets are:
+
+``` js
+// family_document schema
+fieldset default {
+    fields: family_name_index, family_description_index
+}
+
+// document_passage schema
+fieldset default {
+    fields: text_block
+}
+```
+
 ## Exact search
 
 The intention of this search is to return documents with the *exact phrase used* in their titles, descriptions or full text. Expert users tend to use this when they're searching for something very specific and often technical, or to count documents that mention a phrase. (Having said that, around 1% of users performed this search before we recently made it harder to find).
 
-### Annotated YQL
+Like default text search, exact search uses the same grouping structure — the difference is in retrieval and ranking. Instead of `userInput`, it uses `contains` with stemming disabled, and selects the `exact_not_stemmed` rank profile.
+
+### Annotated exact search YQL
 
 ```sql
 -- RETRIEVAL PART
@@ -158,7 +200,7 @@ all(
 )
 ```
 
-### Relevant parts of schemas
+### Relevant schema parts for exact search
 
 #### `family_document` schema
 
@@ -232,89 +274,3 @@ rank-profile exact_not_stemmed inherits default_passage {
     summary-features: query(passage_weight) text_score()
 }
 ```
-
-## Hybrid search
-
-Hybrid search is the default search on our tool. It's implementation is similar to exact match search, but with a few extra parts to the query and schema. Here, just the differences will be highlighted.
-
-### Annotated YQL
-
-The group clause is exactly the same as before! But in the retrieval part, instead of using `contains` we use:
-
-- [userInput](https://docs.vespa.ai/en/reference/query-language-reference.html#userinput): Vespa's way of turning a free text query into the lower-level query that it thinks is most suitable. Operates on the *default fieldset* defined in each schema.
-- [nearestNeighbour](https://docs.vespa.ai/en/nearest-neighbor-search.html#querying-using-nearestneighbor-query-operator): performs approximate nearest neighbour search using an embedding of the query and the `text_embedding` field, which is the the vector-encoded version of each text block. This is what makes our search 'semantic'.
-
-``` sql
-select * from sources family_document, document_passage where ( 
-    ---
-    (userInput(@query_string)) 
-    or ( 
-        [{\"targetNumHits\": 1000}] nearestNeighbor(text_embedding,query_embedding) ) 
-    ) 
-    limit 0 
-| all( 
-    group(family_import_id) 
-    output(count()) max(20) 
-    each( output(count()) max(10) each( output( summary(search_summary) ) ) ) 
-)
-```
-
-### Relevant parts of schemas
-
-The ranking for each field is as follows:
-
-- family names are ranked using BM25.
-- family descriptions are ranked using a weighted sum of BM25 and vector similarity. The weight of the latter is set to 0 in the SDK, disabling vector search on descriptions.
-- passages are ranked using a weighted sum of BM25 and vector similarity.
-
-[BM25](https://en.wikipedia.org/wiki/Okapi_BM25) ranks according to the number of times a term in the query appears in each record, penalising occurrences (like 'climate') which appear in lots of records compared to those that are rarer.
-
-> [!TIP]
-> The `description_closeness_weight` has been set to 0 in the SDK code, rather than updating the default value in the schema. This method doesn't require a Vespa schema change thus redeploy, and changing values in code rather than the schema means SDK and backend unit tests can be run on the change.
-
-``` js
-// family_document hybrid rank profile
-rank-profile hybrid inherits default_family {
-    inputs {
-        query(query_embedding) tensor<float>(x[768])
-        query(description_bm25_weight) double: 1.0
-        // NOTE: this is set to 0 in the SDK, disabling embedding search on descriptions
-        query(description_closeness_weight) double: 1.0
-    }
-    function name_score() {
-        expression: bm25(family_name_index)
-    }
-    function description_score() {
-        expression: query(description_bm25_weight) * bm25(family_description_index) + query(description_closeness_weight) * closeness(family_description_embedding)
-    }
-    first-phase {
-        expression: (query(name_weight) * name_score()) + (query(description_weight) * description_score())
-    }
-    summary-features: name_score() description_score() bm25(family_name_index) bm25(family_description_index) closeness(family_description_embedding)
-}
-
-// document_passage hybrid rank profile
-rank-profile hybrid inherits default_passage {
-    inputs {
-        query(query_embedding) tensor<float>(x[768])
-        query(passage_bm25_weight) double: 1.0
-        query(passage_closeness_weight) double: 1.0
-    }
-    function text_score() {
-        expression: query(passage_bm25_weight) * bm25(text_block) + query(passage_closeness_weight) * closeness(text_embedding)
-    }
-    first-phase {
-        expression: query(passage_weight) * text_score()
-    }
-    summary-features: text_score() bm25(text_block) closeness(text_embedding) query(passage_weight)
-}
-
-```
-
-### Disabling vector search for sensitive queries
-
-The embedding model we use is trained on English Wikipedia and a dataset of out-of-copyright books then finetuned on thousands of Bing searches (a dataset called msmarco). As a result, there are some troublesome biases that we'd like to avoid our users seeing.
-
-As such, there's an escape hatch for any queries that contain likely sensitive terms including protected characteristics, nationalities, and some miscellaneous terms ([full list here](../../src/cpr_sdk/resources/sensitive_query_terms.tsv)).
-
-The mechanics of the sensitive query are identical to the hybrid search query, but with use of embeddings for both retrieval and ranking removed.

--- a/src/cpr_sdk/cli/search.py
+++ b/src/cpr_sdk/cli/search.py
@@ -1,6 +1,5 @@
 import time
 from contextlib import nullcontext
-from typing import Optional
 
 import typer
 from rich.console import Console
@@ -66,10 +65,6 @@ def main(
         default=[],
         help="Filter results by concept ID. Can be used multiple times in the same run.",
     ),
-    distance_threshold: Optional[float] = typer.Option(
-        default=None,
-        help="Optional threshold for the vector component of hybrid search. Passages with an inner product score below this threshold will be excluded.",
-    ),
 ):
     """Run a search query with different rank profiles."""
     console = Console()
@@ -81,7 +76,6 @@ def main(
         concept_filters=[
             ConceptFilter(name="id", value=concept_id) for concept_id in concept_id
         ],
-        distance_threshold=distance_threshold,
     )
     request_body = build_vespa_request_body(search_parameters)
 

--- a/src/cpr_sdk/models/search.py
+++ b/src/cpr_sdk/models/search.py
@@ -428,13 +428,6 @@ class SearchParameters(BaseModel):
     See docs: https://docs.vespa.ai/en/query-rewriting.html#rule-bases
     """
 
-    distance_threshold: Optional[float] = 0.24
-    """
-    Optional threshold for the nearest neighbor search distance. Results with a
-    distance score below this threshold will be excluded. Based on the 'innerproduct'
-    distance metric, lower scores are less relevant.
-    """
-
     by_document_title: bool = False
     """
     Whether to search by document title rather than family title.

--- a/src/cpr_sdk/version.py
+++ b/src/cpr_sdk/version.py
@@ -1,5 +1,5 @@
-_MAJOR = "4"
-_MINOR = "3"
+_MAJOR = "5"
+_MINOR = "0"
 _PATCH = "0"
 _SUFFIX = ""
 

--- a/src/cpr_sdk/vespa.py
+++ b/src/cpr_sdk/vespa.py
@@ -8,10 +8,9 @@ from vespa.io import VespaQueryResponse
 
 from cpr_sdk.exceptions import FetchError
 from cpr_sdk.models.search import Family, Hit, SearchParameters, SearchResponse
-from cpr_sdk.utils import dig, is_sensitive_query, load_sensitive_query_terms
+from cpr_sdk.utils import dig
 from cpr_sdk.yql_builder import YQLBuilder
 
-SENSITIVE_QUERY_TERMS = load_sensitive_query_terms()
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -88,19 +87,13 @@ def find_vespa_cert_paths() -> tuple[Optional[str], Optional[str]]:
 
 def build_vespa_request_body(parameters: SearchParameters) -> dict[str, str]:
     """Constructs the payload for a vespa query"""
-    sensitive = (
-        is_sensitive_query(parameters.query_string, SENSITIVE_QUERY_TERMS)
-        if parameters.query_string
-        else False
-    )
-
     if parameters.by_document_title and not parameters.documents_only:
         _LOGGER.warning(
             "Searching by document title is not supported when documents_only is False. Setting documents_only to True."
         )
         parameters.documents_only = True
 
-    yql = YQLBuilder(params=parameters, sensitive=sensitive).to_str()
+    yql = YQLBuilder(params=parameters).to_str()
     vespa_request_body: dict[str, Any] = {
         "yql": yql,
         "timeout": "20",
@@ -112,15 +105,8 @@ def build_vespa_request_body(parameters: SearchParameters) -> dict[str, str]:
         pass
     elif parameters.exact_match:
         vespa_request_body["ranking.profile"] = "exact_not_stemmed"
-    elif sensitive:
-        vespa_request_body["ranking.profile"] = "hybrid_no_closeness"
     elif parameters.by_document_title:
         vespa_request_body["ranking.profile"] = "bm25_document_title"
-    else:
-        vespa_request_body["ranking.profile"] = "hybrid"
-        vespa_request_body["input.query(query_embedding)"] = (
-            "embed(msmarco-distilbert-dot-v5, @query_string)"
-        )
 
     if parameters.custom_vespa_request_body is not None:
         overlapping_keys = set(vespa_request_body.keys()) & set(
@@ -141,9 +127,6 @@ def build_vespa_request_body(parameters: SearchParameters) -> dict[str, str]:
         else:
             vespa_request_body["rules.off"] = False
             vespa_request_body["rules.rulebase"] = "acronyms"
-
-    # Disabling embedding search for descriptions
-    vespa_request_body["input.query(description_closeness_weight)"] = 0
 
     return vespa_request_body
 

--- a/src/cpr_sdk/yql_builder.py
+++ b/src/cpr_sdk/yql_builder.py
@@ -40,9 +40,8 @@ class YQLBuilder:
     """
     )
 
-    def __init__(self, params: SearchParameters, sensitive: bool = False) -> None:
+    def __init__(self, params: SearchParameters) -> None:
         self.params = params
-        self.sensitive = sensitive
 
     def _escape_apostrophes(self, value: Optional[str]) -> str:
         """Escape a apostrophes for safe inclusion in a single-quoted YQL literal."""
@@ -59,20 +58,14 @@ class YQLBuilder:
 
     def build_search_term(self) -> str:
         """Create the part of the query that matches a users search text"""
-        if self.params.all_results:
+        if self.params.all_results or not self.params.query_string:
             return "( true )"
-        if self.params.exact_match:
+        elif self.params.exact_match:
             return """
                 (
                     (family_name_not_stemmed contains({stem: false}@query_string)) or
                     (family_description_not_stemmed contains({stem: false}@query_string)) or
                     (text_block_not_stemmed contains ({stem: false}@query_string))
-                )
-            """
-        elif self.sensitive:
-            return """
-                (
-                    (userInput(@query_string)) 
                 )
             """
         elif self.params.by_document_title:
@@ -82,21 +75,9 @@ class YQLBuilder:
                 )
             """
         else:
-            # if specified in the search parameters, add a threshold for the distance
-            # between the query and the text_embedding
-            distance_threshold_clause = (
-                f', "distanceThreshold": {self.params.distance_threshold}'
-                if self.params.distance_threshold is not None
-                else ""
-            )
-
-            return f"""
+            return """
                 (
-                    (userInput(@query_string)) 
-                    or (
-                        [{{\"targetNumHits\": 1000{distance_threshold_clause}}}]
-                        nearestNeighbor(text_embedding,query_embedding)
-                    )
+                    (userInput(@query_string))
                 )
             """
 

--- a/tests/test_search_adaptors.py
+++ b/tests/test_search_adaptors.py
@@ -294,7 +294,7 @@ def test_vespa_search_adaptor_rank_features(test_vespa):
 
     for family in response.results:
         for hit in family.hits:
-            assert isinstance(hit.rank_features, dict)
+            assert hit.rank_features is None or isinstance(hit.rank_features, dict)
 
 
 @pytest.mark.vespa
@@ -305,7 +305,7 @@ async def test_vespa_async_search_adaptor_rank_features(test_vespa):
 
     for family in response.results:
         for hit in family.hits:
-            assert isinstance(hit.rank_features, dict)
+            assert hit.rank_features is None or isinstance(hit.rank_features, dict)
 
 
 @pytest.mark.vespa
@@ -617,26 +617,6 @@ async def test_vespa_async_search_adaptor__exact(test_vespa):
     request = SearchParameters(query_string=query_string, exact_match=True)
     response = await async_vespa_search(test_vespa, request)
     assert len(response.results) == 0
-
-
-@pytest.mark.vespa
-@patch("cpr_sdk.vespa.SENSITIVE_QUERY_TERMS", {"Government"})
-def test_vespa_search_adaptor__sensitive(test_vespa):
-    request = SearchParameters(query_string="Government")
-    response = vespa_search(test_vespa, request)
-
-    # Without being too prescriptive, we'd expect something back for this
-    assert len(response.results) > 0
-
-
-@pytest.mark.vespa
-@pytest.mark.asyncio
-async def test_vespa_async_search_adaptor__sensitive(test_vespa):
-    request = SearchParameters(query_string="Government")
-    response = await async_vespa_search(test_vespa, request)
-
-    # Without being too prescriptive, we'd expect something back for this
-    assert len(response.results) > 0
 
 
 @pytest.mark.parametrize(
@@ -1623,143 +1603,6 @@ def test_vespa_search_response__geographies(
 
 
 @pytest.mark.vespa
-def test_vespa_search_hybrid_no_closeness_profile(test_vespa):
-    query_string = "the"
-
-    request_no_closeness = SearchParameters(
-        query_string=query_string,
-        custom_vespa_request_body={"ranking.profile": "hybrid_no_closeness"},
-    )
-    response_no_closeness = vespa_search(test_vespa, request_no_closeness)
-
-    request_null_closeness_weights = SearchParameters(
-        query_string=query_string,
-        custom_vespa_request_body={
-            "input.query(description_closeness_weight)": 0,
-            "input.query(passage_closeness_weight)": 0,
-        },
-    )
-    response_null_closeness_weights = vespa_search(
-        test_vespa, request_null_closeness_weights
-    )
-
-    assert response_no_closeness == response_null_closeness_weights
-
-
-@pytest.mark.vespa
-@pytest.mark.asyncio
-async def test_vespa_async_search_hybrid_no_closeness_profile(test_vespa):
-    query_string = "the"
-
-    request_no_closeness = SearchParameters(
-        query_string=query_string,
-        custom_vespa_request_body={"ranking.profile": "hybrid_no_closeness"},
-    )
-    response_no_closeness = await async_vespa_search(test_vespa, request_no_closeness)
-
-    request_null_closeness_weights = SearchParameters(
-        query_string=query_string,
-        custom_vespa_request_body={
-            "input.query(description_closeness_weight)": 0,
-            "input.query(passage_closeness_weight)": 0,
-        },
-    )
-    response_null_closeness_weights = await async_vespa_search(
-        test_vespa, request_null_closeness_weights
-    )
-
-    assert response_no_closeness == response_null_closeness_weights
-
-
-@pytest.mark.vespa
-@pytest.mark.parametrize(
-    "weight_name,query_string",
-    [
-        (
-            "name_weight",
-            "Nationally Determined Contribution: Climate Change Adaptation and Low Emissions Growth Strategy by 2035",
-        ),
-        (
-            "description_weight",
-            "forestry and forest resources, biodiversity and sensitive ecosystems",
-        ),
-        ("passage_weight", "climate change adaptation action"),
-    ],
-)
-def test_vespa_search_field_weights(test_vespa, weight_name, query_string):
-    """
-    Test that search results differ when field weights are set to 0.
-
-    TODO: it'd be great if we could focus these tests on whether the field weights
-    actually affect the fields they're supposed to, but there doesn't seem to be a
-    simple way of doing this. The issue could be to do with the lack of diversity
-    of families in the test data.
-    """
-    response = vespa_search(
-        test_vespa,
-        SearchParameters(
-            query_string=query_string,
-        ),
-    )
-
-    response_null_field_weight = vespa_search(
-        test_vespa,
-        SearchParameters(
-            query_string=query_string,
-            custom_vespa_request_body={
-                f"input.query({weight_name})": 0,
-            },
-        ),
-    )
-
-    assert response.results != response_null_field_weight.results
-
-
-@pytest.mark.vespa
-@pytest.mark.parametrize(
-    "weight_name,query_string",
-    [
-        (
-            "name_weight",
-            "Nationally Determined Contribution: Climate Change Adaptation and Low Emissions Growth Strategy by 2035",
-        ),
-        (
-            "description_weight",
-            "forestry and forest resources, biodiversity and sensitive ecosystems",
-        ),
-        ("passage_weight", "climate change adaptation action"),
-    ],
-)
-@pytest.mark.asyncio
-async def test_vespa_async_search_field_weights(test_vespa, weight_name, query_string):
-    """
-    Test that search results differ when field weights are set to 0.
-
-    TODO: it'd be great if we could focus these tests on whether the field weights
-    actually affect the fields they're supposed to, but there doesn't seem to be a
-    simple way of doing this. The issue could be to do with the lack of diversity
-    of families in the test data.
-    """
-    response = await async_vespa_search(
-        test_vespa,
-        SearchParameters(
-            query_string=query_string,
-        ),
-    )
-
-    response_null_field_weight = await async_vespa_search(
-        test_vespa,
-        SearchParameters(
-            query_string=query_string,
-            custom_vespa_request_body={
-                f"input.query({weight_name})": 0,
-            },
-        ),
-    )
-
-    assert response.results != response_null_field_weight.results
-
-
 @pytest.mark.vespa
 @pytest.mark.parametrize(
     "concept_count_filters,expected_response_families,sort_by,sort_order",

--- a/tests/test_search_requests.py
+++ b/tests/test_search_requests.py
@@ -1,6 +1,3 @@
-import re
-from unittest.mock import patch
-
 import pytest
 from pydantic import ValidationError
 
@@ -8,16 +5,12 @@ from cpr_sdk.models.search import Filters, SearchParameters, sort_fields, sort_o
 from cpr_sdk.vespa import build_vespa_request_body
 
 
-@patch(
-    "cpr_sdk.vespa.SENSITIVE_QUERY_TERMS",
-    {re.compile(r"\b" + re.escape("sensitive") + r"\b")},
-)
 @pytest.mark.parametrize(
     "expected_rank_profile, params",
     [
-        ("hybrid", SearchParameters(query_string="test")),
+        (None, SearchParameters()),
+        (None, SearchParameters(query_string="test")),
         ("exact_not_stemmed", SearchParameters(query_string="test", exact_match=True)),
-        ("hybrid_no_closeness", SearchParameters(query_string="sensitive")),
         (
             "bm25_document_title",
             SearchParameters(query_string="test", by_document_title=True),
@@ -26,11 +19,16 @@ from cpr_sdk.vespa import build_vespa_request_body
 )
 def test_build_vespa_request_body(expected_rank_profile, params):
     body = build_vespa_request_body(parameters=params)
-    assert body["ranking.profile"] == expected_rank_profile
+    assert body.get("ranking.profile") == expected_rank_profile
     for key, value in body.items():
         assert (
             not isinstance(value, str) or len(value) > 0
         ), f"Search parameters: {params} has an empty value for {key}: {value}"
+
+
+def test_build_vespa_request_body__default_has_no_ranking_profile():
+    body = build_vespa_request_body(parameters=SearchParameters(query_string="test"))
+    assert "ranking.profile" not in body
 
 
 def test_build_vespa_request_body__all():

--- a/tests/test_yql_builder.py
+++ b/tests/test_yql_builder.py
@@ -113,26 +113,17 @@ def test_filter_profiles_return_different_queries():
         params=SearchParameters(
             query_string="test", year_range=(2000, 2023), exact_match=True
         ),
-        sensitive=False,
     ).to_str()
     assert "stem: false" in exact_yql
     assert "nearestNeighbor" not in exact_yql
 
-    hybrid_yql = YQLBuilder(
+    default_yql = YQLBuilder(
         params=SearchParameters(
             query_string="test", year_range=(2000, 2023), exact_match=False
         ),
-        sensitive=False,
     ).to_str()
-    assert "nearestNeighbor" in hybrid_yql
-
-    sensitive_yql = YQLBuilder(
-        params=SearchParameters(
-            query_string="test", year_range=(2000, 2023), exact_match=False
-        ),
-        sensitive=True,
-    ).to_str()
-    assert "nearestNeighbor" not in sensitive_yql
+    assert "nearestNeighbor" not in default_yql
+    assert "userInput" in default_yql
 
     all_yql = YQLBuilder(
         params=SearchParameters(
@@ -143,7 +134,7 @@ def test_filter_profiles_return_different_queries():
     assert "2024" in all_yql
     assert "test query string" not in all_yql
 
-    queries = [exact_yql, hybrid_yql, sensitive_yql, all_yql]
+    queries = [exact_yql, default_yql, all_yql]
     assert len(queries) == len(set(queries))
 
 
@@ -212,23 +203,6 @@ def test_yql_builder_build_concept_count_filter() -> None:
     assert concept_count_filter_clause.replace("  ", "").replace("\n", "") == (
         '((concept_counts contains sameElement(key contains "concept_1_1", value = 101)))'
     )
-
-
-def test_distance_threshold_appears_in_yql():
-    """Test whether the distance_threshold clause appears in the YQL when specified."""
-    # Test with distance_threshold set
-    threshold = 0.7
-    params_with_threshold = SearchParameters(
-        query_string="test", distance_threshold=threshold
-    )
-    yql_with_threshold = YQLBuilder(params_with_threshold).to_str()
-    expected_substring = f'"distanceThreshold": {threshold}'
-    assert expected_substring in yql_with_threshold
-
-    # Test with distance_threshold (default is a Float)
-    params_without_threshold = SearchParameters(query_string="test")
-    yql_without_threshold = YQLBuilder(params_without_threshold).to_str()
-    assert "distanceThreshold" in yql_without_threshold
 
 
 def test_by_document_title_appears_in_yql():
@@ -419,7 +393,7 @@ def test_concept_v2_filters_appear_in_yql():
     yql = YQLBuilder(params).to_str()
     assert (
         yql
-        == 'select * from sources family_document, document_passage where ( (userInput(@query_string)) or ( [{"targetNumHits": 1000, "distanceThreshold": 0.24}] nearestNeighbor(text_embedding,query_embedding) ) ) and (spans contains sameElement(concepts_v2_flat matches \'Q374\')) limit 0 | all( group(family_import_id) output(count()) max(100) each( output(count()) max(10) each( output( summary(search_summary) ) ) ) )'
+        == "select * from sources family_document, document_passage where ( (userInput(@query_string)) ) and (spans contains sameElement(concepts_v2_flat matches 'Q374')) limit 0 | all( group(family_import_id) output(count()) max(100) each( output(count()) max(10) each( output( summary(search_summary) ) ) ) )"
     )
 
     # Test document filter
@@ -434,7 +408,7 @@ def test_concept_v2_filters_appear_in_yql():
     yql = YQLBuilder(params).to_str()
     assert (
         yql
-        == 'select * from sources family_document, document_passage where ( (userInput(@query_string)) or ( [{"targetNumHits": 1000, "distanceThreshold": 0.24}] nearestNeighbor(text_embedding,query_embedding) ) ) and (concepts_v2 contains sameElement(concept_wikibase_id contains \'Q374\', count >= 5)) limit 0 | all( group(family_import_id) output(count()) max(100) each( output(count()) max(10) each( output( summary(search_summary) ) ) ) )'
+        == "select * from sources family_document, document_passage where ( (userInput(@query_string)) ) and (concepts_v2 contains sameElement(concept_wikibase_id contains 'Q374', count >= 5)) limit 0 | all( group(family_import_id) output(count()) max(100) each( output(count()) max(10) each( output( summary(search_summary) ) ) ) )"
     )
 
     # Test both filters together
@@ -450,7 +424,7 @@ def test_concept_v2_filters_appear_in_yql():
     yql = YQLBuilder(params).to_str()
     assert (
         yql
-        == "select * from sources family_document, document_passage where ( (userInput(@query_string)) or ( [{\"targetNumHits\": 1000, \"distanceThreshold\": 0.24}] nearestNeighbor(text_embedding,query_embedding) ) ) and (spans contains sameElement(concepts_v2_flat matches 'Q374')) and (concepts_v2 contains sameElement(concept_id contains 'nhhzwfva', count = 1)) limit 0 | all( group(family_import_id) output(count()) max(100) each( output(count()) max(10) each( output( summary(search_summary) ) ) ) )"
+        == "select * from sources family_document, document_passage where ( (userInput(@query_string)) ) and (spans contains sameElement(concepts_v2_flat matches 'Q374')) and (concepts_v2 contains sameElement(concept_id contains 'nhhzwfva', count = 1)) limit 0 | all( group(family_import_id) output(count()) max(100) each( output(count()) max(10) each( output( summary(search_summary) ) ) ) )"
     )
 
 


### PR DESCRIPTION
# Description

This PR is part of a set of stacked branches to perform a wholesale removal of embeddings from the query layer and vespa now that embeddings / semantic search have been deprecated. This branch is responsible for addressing the changes required to the vespa query layer.

The `SearchParameters` is the interface to the query layer, this is then used within the sdk to decipher whether to run embeddings search. Therefore, we can change the internal logic here and make no breaking changes to the consumers of this repo. 

## Changes: 

Ranking Profile Removal: 
- Removal of the ranking profiles related to embeddings search. 
- This also meant we removed the `sensitive` parameter as it's only used for `hybrid_no_closeness`. This is only used internally in the query builder so no breaking change. 

Cli distance_threshold Param Removal: 
Removal of `distance_threshold` as a param is a potentially breaking change, but then it's silently not being used anyway? Happy to put a deprecation warning on the field as opposed to wholesale removal. 
```python
distance_threshold: Optional[float] = Field(
    default=None,
    deprecated="distance_threshold has no effect and will be removed in a future version. Embedding-based search has been removed."
)
```

note: is_sensitive_query, load_sensitive_query_terms functions to be cleaned up later. 

## Proposed version

Please select the option below that is most relevant from the list below. This
will be used to generate the next tag version name during auto-tagging.

- [ ] Skip auto-tagging
- [ ] Patch
- [ ] Minor version
- [x] Major version

Visit the [Semver website](https://semver.org/#summary) to understand the
difference between `MAJOR`, `MINOR`, and `PATCH` versions.

Notes:

- If none of these options are selected, auto-tagging will fail (integrated soon)
- Where multiple options are selected, the most senior option ticked will be
  used -- e.g. Major > Minor > Patch
- If you are selecting the version in the list above using the textbox, make
  sure your selected option is marked `[x]` with no spaces in between the
  brackets and the `x`

## Type of change

Please select the option(s) below that are most relevant:

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## How Has This Been Tested?

Please describe the tests that you added to verify your changes.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/climatepolicyradar/cpr-sdk/blob/main/.github/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
